### PR TITLE
refactor(lsp3): rename lsp3profile -> erc725Account

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { LSPFactory } from './lib/lsp-factory';
-export { LSP3UniversalProfile } from './lib/classes/lsp3-universal-profile';
+export { ERC725UniversalProfile } from './lib/classes/erc725-universal-profile';
 export * from './lib/interfaces';
 export * from '../types/ethers-v5';

--- a/src/lib/classes/erc725-universal-profile.spec.ts
+++ b/src/lib/classes/erc725-universal-profile.spec.ts
@@ -1,12 +1,12 @@
 import { providers } from 'ethers';
 import { ethers, SignerWithAddress } from 'hardhat';
 
+import { lsp3ProfileJson } from '../../../test/lsp3-profile.mock';
+import { DeploymentEvent } from '../interfaces';
 import { LSPFactory } from '../lsp-factory';
 
-import { lsp3ProfileJson } from './../../../test/lsp3-profile.mock';
-import { DeploymentEvent } from './../interfaces';
 import { ProxyDeployer } from './proxy-deployer';
-describe('LSP3UniversalProfile', () => {
+describe('ERC725Account', () => {
   let baseContracts;
   let proxyDeployer: ProxyDeployer;
   let signer: SignerWithAddress;
@@ -21,7 +21,7 @@ describe('LSP3UniversalProfile', () => {
   it.skip('should deploy and set LSP3Profile data', (done) => {
     const myLSPFactory = new LSPFactory(provider, signer);
 
-    const deployments$ = myLSPFactory.LSP3UniversalProfile.deployReactive(
+    const deployments$ = myLSPFactory.ERC725Account.deployReactive(
       {
         controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
         lsp3Profile: lsp3ProfileJson,

--- a/src/lib/classes/erc725-universal-profile.ts
+++ b/src/lib/classes/erc725-universal-profile.ts
@@ -22,19 +22,18 @@ import {
   getBaseContractAddresses$,
 } from '../services/base-contract.service';
 import { keyManagerDeployment$ } from '../services/key-manager.service';
-
 import {
   accountDeployment$,
   getLsp3ProfileDataUrl,
   getTransferOwnershipTransaction$,
   setDataTransaction$,
-} from './../services/lsp3-account.service';
-import { universalReceiverAddressStoreDeployment$ } from './../services/universal-receiver.service';
+} from '../services/lsp3-account.service';
+import { universalReceiverAddressStoreDeployment$ } from '../services/universal-receiver.service';
 
 /**
  * TODO: docs
  */
-export class LSP3UniversalProfile {
+export class ERC725UniversalProfile {
   options: LSPFactoryOptions;
   signer: NonceManager;
   constructor(options: LSPFactoryOptions) {
@@ -55,14 +54,14 @@ export class LSP3UniversalProfile {
       : null;
 
     // 0 > Check for existing base contracts and deploy
-    const defaultLSP3BaseContractAddress =
-      contractVersions[this.options.chainId]?.baseContracts?.LSP3Account['0.0.1'];
+    const defaultERC725AccountBaseContractAddress =
+      contractVersions[this.options.chainId]?.baseContracts?.ERC725Account['0.0.1'];
     const defaultUniversalReceiverBaseContractAddress =
       contractVersions[this.options.chainId]?.baseContracts?.UniversalReceiverAddressStore['0.0.1'];
 
     const defaultBaseContractByteCode$ = forkJoin([
       this.getDeployedByteCode(
-        defaultLSP3BaseContractAddress ?? '0x0000000000000000000000000000000000000000'
+        defaultERC725AccountBaseContractAddress ?? '0x0000000000000000000000000000000000000000'
       ),
       this.getDeployedByteCode(
         defaultUniversalReceiverBaseContractAddress ?? '0x0000000000000000000000000000000000000000'
@@ -70,7 +69,7 @@ export class LSP3UniversalProfile {
     ]);
 
     const baseContractAddresses$ = getBaseContractAddresses$(
-      defaultLSP3BaseContractAddress,
+      defaultERC725AccountBaseContractAddress,
       defaultUniversalReceiverBaseContractAddress,
       defaultBaseContractByteCode$,
       this.signer,
@@ -129,6 +128,7 @@ export class LSP3UniversalProfile {
       contractDeploymentOptions
     ).pipe(
       scan((accumulator: DeployedContracts, deploymentEvent: DeploymentEvent) => {
+        console.log(deploymentEvent);
         if (deploymentEvent.receipt && deploymentEvent.receipt.contractAddress) {
           accumulator[deploymentEvent.contractName] = {
             address: deploymentEvent.receipt.contractAddress,
@@ -169,7 +169,7 @@ export class LSP3UniversalProfile {
   }
 
   /**
-   * Pre-deploys the latest Version of the LSP3UniversalProfile smart-contracts.
+   * Pre-deploys the latest Version of the ERC725Account smart-contracts.
    *
    * @param {'string'} [version] Instead of deploying the latest Version you can also deploy a specific
    *  version of the smart-contracts. A list of all available version is available here.
@@ -179,7 +179,7 @@ export class LSP3UniversalProfile {
   }
 
   /**
-   * Uploads the LSP3Profile to the desired endpoint. This can be an `https` URL either pointing to
+   * Uploads the LSP3UniversalProfile to the desired endpoint. This can be an `https` URL either pointing to
    * a public, centralized storage endpoint or an IPFS Node / Cluster
    *
    * @param {ProfileDataBeforeUpload} profileData

--- a/src/lib/classes/proxy-deployer.spec.ts
+++ b/src/lib/classes/proxy-deployer.spec.ts
@@ -2,7 +2,7 @@ import { ethers, SignerWithAddress } from 'hardhat';
 
 import { ProxyDeployer } from './proxy-deployer';
 
-describe('LSP3UniversalProfile', () => {
+describe('ERC725Account', () => {
   let baseContracts;
   let proxyDeployer;
   let signer: SignerWithAddress;

--- a/src/lib/helpers/deployment.helper.spec.ts
+++ b/src/lib/helpers/deployment.helper.spec.ts
@@ -8,7 +8,7 @@ import { waitForReceipt } from './deployment.helper';
 describe('waitForReceipt', () => {
   describe('with type PROXY', () => {
     it('should return a new deployment event with the receipt', (done) => {
-      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.LSP3Account.deployment;
+      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.ERC725Account.deployment;
       const deploymentEvent$ = of(expectedDeploymentEvent);
       const receipt$ = waitForReceipt(deploymentEvent$);
 
@@ -25,7 +25,7 @@ describe('waitForReceipt', () => {
     });
 
     it('should return a new deployment event with the receipt, functionName', (done) => {
-      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.LSP3Account.initialize;
+      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.ERC725Account.initialize;
       const expectedDeploymentEvent$ = of(expectedDeploymentEvent);
       const receipt$ = waitForReceipt(expectedDeploymentEvent$);
 
@@ -43,7 +43,7 @@ describe('waitForReceipt', () => {
     });
 
     it('should throw an error incase transaction.wait() fails/errors', (done) => {
-      const expectedDeploymentEvent$ = of(defaultDeploymentEvents.PROXY.LSP3Account.error);
+      const expectedDeploymentEvent$ = of(defaultDeploymentEvents.PROXY.ERC725Account.error);
       const receipt$ = waitForReceipt(expectedDeploymentEvent$);
 
       receipt$.subscribe({

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -21,7 +21,7 @@ export enum DeploymentStatus {
 }
 
 export enum ContractNames {
-  LSP3_ACCOUNT = 'LSP3Account',
+  ERC725_ACCOUNT = 'ERC725Account',
   KEY_MANAGER = 'KeyManager',
   UNIVERSAL_RECEIVER = 'UniversalReceiverAddressStore',
 }
@@ -38,7 +38,7 @@ export interface ProfileDeploymentOptions {
   controllingAccounts: (string | ControllerOptions)[];
   lsp3Profile?: ProfileDataBeforeUpload | string;
   baseContractAddresses?: {
-    lsp3Account?: string;
+    erc725Account?: string;
     universalReceiverAddressStore?: string;
     keyManager?: string;
   };
@@ -97,7 +97,7 @@ export interface BaseContractAddresses {
 export interface ContractDeploymentOptions {
   version?: string;
   byteCode?: {
-    lsp3AccountInit: string;
+    erc725AccountInit: string;
     keyManagerInit: string;
     universalReceiverAddressStoreInit: string;
   };

--- a/src/lib/lsp-factory.ts
+++ b/src/lib/lsp-factory.ts
@@ -1,6 +1,6 @@
 import { ethers, providers, Signer } from 'ethers';
 
-import { LSP3UniversalProfile } from './classes/lsp3-universal-profile';
+import { ERC725UniversalProfile } from './classes/erc725-universal-profile';
 import { ProxyDeployer } from './classes/proxy-deployer';
 import { LSPFactoryOptions } from './interfaces';
 import { SignerOptions } from './interfaces/lsp-factory-options';
@@ -10,7 +10,7 @@ import { SignerOptions } from './interfaces/lsp-factory-options';
  */
 export class LSPFactory {
   options: LSPFactoryOptions;
-  LSP3UniversalProfile: LSP3UniversalProfile;
+  ERC725UniversalProfile: ERC725UniversalProfile;
   ProxyDeployer: ProxyDeployer;
   /**
    * TBD
@@ -51,7 +51,7 @@ export class LSPFactory {
       chainId,
     };
 
-    this.LSP3UniversalProfile = new LSP3UniversalProfile(this.options);
+    this.ERC725UniversalProfile = new ERC725UniversalProfile(this.options);
     this.ProxyDeployer = new ProxyDeployer(this.options.signer);
   }
 }

--- a/src/lib/services/base-contract.service.ts
+++ b/src/lib/services/base-contract.service.ts
@@ -12,7 +12,7 @@ export function baseContractsDeployment$(
   baseContractsToDeploy$: Observable<[boolean, boolean]>
 ): Observable<DeploymentEventContract> {
   const lsp3AccountBaseContractDeploymentReceipt$ = deployBaseContract$(
-    ContractNames.LSP3_ACCOUNT,
+    ContractNames.ERC725_ACCOUNT,
     () => {
       return new LSP3AccountInit__factory(signer).deploy();
     }
@@ -84,7 +84,7 @@ export function getBaseContractAddresses$(
   );
 
   const baseContractAddresses = {
-    [ContractNames.LSP3_ACCOUNT]: providedLSP3BaseContractAddress ?? defaultLSP3BaseContractAddress,
+    [ContractNames.ERC725_ACCOUNT]: providedLSP3BaseContractAddress ?? defaultLSP3BaseContractAddress,
     [ContractNames.UNIVERSAL_RECEIVER]:
       providedUniversalReceiverContractAddress ?? defaultUniversalReceiverBaseContractAddress,
   };

--- a/src/lib/services/key-manager.service.ts
+++ b/src/lib/services/key-manager.service.ts
@@ -6,13 +6,13 @@ import { KeyManager__factory } from '../..';
 import { deployContract, waitForReceipt } from '../helpers/deployment.helper';
 import { ContractNames, DeploymentEventContract } from '../interfaces';
 
-import { LSP3AccountDeploymentEvent } from './lsp3-account.service';
+import { ERC725AccountDeploymentEvent } from './lsp3-account.service';
 
 export type KeyManagerDeploymentEvent = DeploymentEventContract;
 
 export function keyManagerDeployment$(
   signer: Signer,
-  accountDeployment$: Observable<LSP3AccountDeploymentEvent>,
+  accountDeployment$: Observable<ERC725AccountDeploymentEvent>,
   baseContractAddress: string
 ) {
   const keyManagerDeployment$ = accountDeployment$.pipe(

--- a/src/lib/services/universal-receiver.service.ts
+++ b/src/lib/services/universal-receiver.service.ts
@@ -17,7 +17,7 @@ import {
 } from '../helpers/deployment.helper';
 import { ContractNames } from '../interfaces';
 
-import { LSP3AccountDeploymentEvent } from './lsp3-account.service';
+import { ERC725AccountDeploymentEvent } from './lsp3-account.service';
 
 export type UniversalReveiverDeploymentEvent =
   | DeploymentEventContract
@@ -25,9 +25,9 @@ export type UniversalReveiverDeploymentEvent =
 
 export function universalReceiverAddressStoreDeployment$(
   signer: Signer,
-  accountDeployment$: Observable<LSP3AccountDeploymentEvent>,
+  accountDeployment$: Observable<ERC725AccountDeploymentEvent>,
   baseContractDeployment$: Observable<{
-    LSP3Account: string;
+    ERC725Account: string;
     UniversalReceiverAddressStore: string;
   }>
 ) {
@@ -45,7 +45,7 @@ export function universalReceiverAddressStoreDeployment$(
 
 export function universalReceiverAddressStoreDeploymentWithBaseContractAddress$(
   signer: Signer,
-  accountDeployment$: Observable<LSP3AccountDeploymentEvent>,
+  accountDeployment$: Observable<ERC725AccountDeploymentEvent>,
   baseContractAddress: string
 ): Observable<UniversalReveiverDeploymentEvent> {
   const universalReceiverAddressStoreDeployment$ = accountDeployment$.pipe(

--- a/src/versions.json
+++ b/src/versions.json
@@ -4,7 +4,7 @@
         "chainId": 22,
         "networkId": 22,
         "baseContracts": {
-            "LSP3Account": {
+            "ERC725Account": {
                 "0.0.1": "0xf5059a5D33d5853360D16C683c16e67980206f36"
             },
             "UniversalReceiverAddressStore": {

--- a/test/deployment-events.mock.ts
+++ b/test/deployment-events.mock.ts
@@ -2,7 +2,7 @@ import { ContractNames, DeploymentStatus, DeploymentType } from '../src';
 
 const proxyDeploymentEventBase = {
   type: DeploymentType.PROXY,
-  contractName: ContractNames.LSP3_ACCOUNT,
+  contractName: ContractNames.ERC725_ACCOUNT,
   status: DeploymentStatus.PENDING,
   transaction: {
     wait: async () => {
@@ -12,7 +12,7 @@ const proxyDeploymentEventBase = {
 };
 export const defaultDeploymentEvents = {
   [DeploymentType.PROXY]: {
-    [ContractNames.LSP3_ACCOUNT]: {
+    [ContractNames.ERC725_ACCOUNT]: {
       deployment: {
         ...proxyDeploymentEventBase,
       },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Rename

- **What is the current behavior?** (You can also link to an open issue here)
LSP3 refers to both contract and metadata standard

- **What is the new behavior (if this is a feature change)?**
- ERC725Account is Contract standard, LSP3 is metadata standard

- **Other information**:
