### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 1.1.0 (2021-11-01)
+### 1.1.1 (2021-11-02)
 
 
 ### ⚠ BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukso/lsp-factory.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukso/lsp-factory.js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@erc725/erc725.js": "^0.6.2-beta.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukso/lsp-factory.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Helper Library to allow simple deployments of LSP3UniversalProfiles and LSP4DigitalCertificates",
   "main": "build/main/src/index.js",
   "typings": "build/main/src/index.d.ts",


### PR DESCRIPTION
v1.1.0 was already published in npm in `2021-08-30T12:22:02.169Z` so publishing v1.1.1