### PR TITLE
chrore(contract): rename lsp3Account to erc725Account

### DIFF
--- a/docs/constructing-lsp3-data.md
+++ b/docs/constructing-lsp3-data.md
@@ -32,7 +32,7 @@ const myUniversalProfileData = {
         },
     ],
     tags: ['Fashion', 'Design'],
-    links: ['www.my-website.com'],
+    links: [{ title: "My Website", url: "www.my-website.com" }],
 },
 ```
 
@@ -50,7 +50,7 @@ const myUniversalProfileData = {
         profileImage: myLocalFile,
         backgroundImage: myLocalFile,
         tags: ['Fashion', 'Design'],
-        links: ['www.my-website.com'],
+        links: [{ title: "My Website", url: "www.my-website.com" }],
     },
 <script/>
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,10 +20,14 @@ npm install @lukso/lsp-factory.js
 ```javascript
 import { LSPFactory } from "@lukso/lsp-factory.js";
 
-const signer = '0x...' // Private key of the account which will deploy UPs
+const deployKey = '0x...' // Private key of the account which will deploy UPs
 const provider = "https://rpc.l14.lukso.network" // RPC url used to connect to the network
+const chainId = 22 // Chain Id of the network you want to connect to
 
-const lspFactory = new LSPFactory(signer, provider);
+const lspFactory = new LSPFactory(provider,  {
+  deployKey,
+  chainId
+});
 ```
 
 ## Usage
@@ -64,7 +68,7 @@ const myUniversalProfileData = {
       },
     ],
     tags: ['Fashion', 'Design'],
-    links: ['www.my-website.com'],
+    links: [{ title: "My Website", url: "www.my-website.com" }],
 },
 ```
 

--- a/docs/reactive-deployment.md
+++ b/docs/reactive-deployment.md
@@ -41,8 +41,8 @@ The function defined in `complete` will be called once after deployment is finis
   { type: "PROXY",        contractName: 'UniversalReceiver...',    functionName: 'initialize',        status: 'PENDING',  transaction:  {} },
   { type: "PROXY",        contractName: 'UniversalReceiver...',    functionName: 'initialize',        status: 'COMPLETE', receipt:      {} },
 
-  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'setDataMultiple',   status: 'PENDING',  transaction:  {} },
-  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'setDataMultiple',   status: 'COMPLETE', receipt:      {} },
+  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'setData',   status: 'PENDING',  transaction:  {} },
+  { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'setData',   status: 'COMPLETE', receipt:      {} },
 
   { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'transferOwnership', status: 'PENDING',  transaction:  {} },
   { type: 'TRANSACTION',  contractName: 'ERC725Account',           functionName: 'transferOwnership', status: 'COMPLETE', receipt:      {} },

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -28,7 +28,7 @@ describe('LSP3UniversalProfile', () => {
       },
       {
         libAddresses: {
-          lsp3AccountInit: baseContracts.lsp3Account.address,
+          erc725AccountInit: baseContracts.universalProfile.address,
           universalReceiverDelegateInit: baseContracts.UniversalReceiverDelegate.address,
         },
       }
@@ -45,18 +45,18 @@ describe('LSP3UniversalProfile', () => {
         done();
       },
       complete: async () => {
-        const ownerAddress = await events.LSP3Account.contract.owner();
+        const ownerAddress = await events.ERC725Account.contract.owner();
         // const keyManagerAddress = await events.KeyManager.contract.address;
         expect(ownerAddress).toEqual('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
 
-        await events.LSP3Account.contract.setData(
+        await events.ERC725Account.contract.setData(
           '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
           '0xbeefbeef',
           {
             from: await signer.getAddress(),
           }
         );
-        const data = await events.LSP3Account.contract.getData(
+        const data = await events.ERC725Account.contract.getData(
           '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
         );
 

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -53,8 +53,10 @@ export class LSP3UniversalProfile {
       : null;
 
     // 0 > Check for existing base contracts and deploy
-    const defaultLSP3BaseContractAddress =
-      contractVersions[this.options.chainId]?.baseContracts?.LSP3Account[DEFAULT_CONTRACT_VERSION];
+    const defaultUPBaseContractAddress =
+      contractVersions[this.options.chainId]?.baseContracts?.ERC725Account[
+        DEFAULT_CONTRACT_VERSION
+      ];
     const defaultUniversalReceiverBaseContractAddress =
       contractVersions[this.options.chainId]?.baseContracts?.UniversalReceiverDelegate[
         DEFAULT_CONTRACT_VERSION
@@ -62,7 +64,7 @@ export class LSP3UniversalProfile {
 
     const defaultBaseContractByteCode$ = forkJoin([
       this.getDeployedByteCode(
-        defaultLSP3BaseContractAddress ?? '0x0000000000000000000000000000000000000000'
+        defaultUPBaseContractAddress ?? '0x0000000000000000000000000000000000000000'
       ),
       this.getDeployedByteCode(
         defaultUniversalReceiverBaseContractAddress ?? '0x0000000000000000000000000000000000000000'
@@ -70,7 +72,7 @@ export class LSP3UniversalProfile {
     ]);
 
     const baseContractAddresses$ = getBaseContractAddresses$(
-      defaultLSP3BaseContractAddress,
+      defaultUPBaseContractAddress,
       defaultUniversalReceiverBaseContractAddress,
       defaultBaseContractByteCode$,
       this.signer,

--- a/src/lib/helpers/deployment.helper.spec.ts
+++ b/src/lib/helpers/deployment.helper.spec.ts
@@ -8,7 +8,7 @@ import { waitForReceipt } from './deployment.helper';
 describe('waitForReceipt', () => {
   describe('with type PROXY', () => {
     it('should return a new deployment event with the receipt', (done) => {
-      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.LSP3Account.deployment;
+      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.ERC725Account.deployment;
       const deploymentEvent$ = of(expectedDeploymentEvent);
       const receipt$ = waitForReceipt(deploymentEvent$);
 
@@ -25,7 +25,7 @@ describe('waitForReceipt', () => {
     });
 
     it('should return a new deployment event with the receipt, functionName', (done) => {
-      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.LSP3Account.initialize;
+      const expectedDeploymentEvent = defaultDeploymentEvents.PROXY.ERC725Account.initialize;
       const expectedDeploymentEvent$ = of(expectedDeploymentEvent);
       const receipt$ = waitForReceipt(expectedDeploymentEvent$);
 
@@ -43,7 +43,7 @@ describe('waitForReceipt', () => {
     });
 
     it('should throw an error incase transaction.wait() fails/errors', (done) => {
-      const expectedDeploymentEvent$ = of(defaultDeploymentEvents.PROXY.LSP3Account.error);
+      const expectedDeploymentEvent$ = of(defaultDeploymentEvents.PROXY.ERC725Account.error);
       const receipt$ = waitForReceipt(expectedDeploymentEvent$);
 
       receipt$.subscribe({

--- a/src/lib/helpers/deployment.helper.ts
+++ b/src/lib/helpers/deployment.helper.ts
@@ -62,7 +62,10 @@ export function initialize(
     switchMap(async (result) => {
       const contract = await factory.attach(result.receipt.contractAddress);
       const initializeParams = await initArguments(result);
-      const transaction = await contract.initialize(...initializeParams, { gasLimit: 3_000_000 });
+      const transaction = await contract.initialize(...initializeParams, {
+        gasLimit: 3_000_000,
+        gasPrice: 10_000_000_000,
+      });
       return {
         type: result.type,
         contractName: result.contractName,

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -4,7 +4,7 @@ import { UniversalProfile, UniversalReceiverDelegate } from '../../';
 import { ProfileDataBeforeUpload } from './lsp3-profile';
 
 export enum ContractNames {
-  LSP3_ACCOUNT = 'LSP3Account',
+  ERC725_Account = 'ERC725Account',
   KEY_MANAGER = 'KeyManager',
   UNIVERSAL_RECEIVER = 'UniversalReceiverDelegate',
 }
@@ -21,19 +21,19 @@ export interface ProfileDeploymentOptions {
   controllingAccounts: (string | ControllerOptions)[];
   lsp3Profile?: ProfileDataBeforeUpload | string;
   baseContractAddresses?: {
-    lsp3Account?: string;
+    erc725Account?: string;
     universalReceiverDelegate?: string;
     keyManager?: string;
   };
 }
 export interface DeployedContracts {
-  LSP3Account?: UniversalProfile;
+  ERC725Account?: UniversalProfile;
   KeyManager: KeyManager;
   UniversalReceiverDelegate: UniversalReceiverDelegate;
 }
 
 export interface BaseContractAddresses {
-  lsp3AccountInit?: string;
+  erc725AccountInit?: string;
   keyManagerInit?: string;
   universalReceiverDelegateInit?: string;
 }
@@ -41,7 +41,7 @@ export interface BaseContractAddresses {
 export interface ContractDeploymentOptions {
   version?: string;
   byteCode?: {
-    lsp3AccountInit: string;
+    erc725AccountInit: string;
     keyManagerInit: string;
     universalReceiverDelegateInit: string;
   };

--- a/src/lib/services/base-contract.service.ts
+++ b/src/lib/services/base-contract.service.ts
@@ -15,8 +15,8 @@ export function baseContractsDeployment$(
   signer: Signer,
   baseContractsToDeploy$: Observable<[boolean, boolean]>
 ): Observable<DeploymentEventContract> {
-  const lsp3AccountBaseContractDeploymentReceipt$ = deployBaseContract$(
-    ContractNames.LSP3_ACCOUNT,
+  const erc725AccountBaseContractDeploymentReceipt$ = deployBaseContract$(
+    ContractNames.ERC725_Account,
     () => {
       return new UniversalProfileInit__factory(signer).deploy();
     }
@@ -30,9 +30,9 @@ export function baseContractsDeployment$(
   );
 
   const baseContractDeployment$ = baseContractsToDeploy$.pipe(
-    switchMap(([shouldDeployLSP3BaseContract, shouldDeployUniversalReceiverBaseContract]) => {
+    switchMap(([shouldDeployUPBaseContract, shouldDeployUniversalReceiverBaseContract]) => {
       return merge(
-        shouldDeployLSP3BaseContract ? lsp3AccountBaseContractDeploymentReceipt$ : EMPTY,
+        shouldDeployUPBaseContract ? erc725AccountBaseContractDeploymentReceipt$ : EMPTY,
         shouldDeployUniversalReceiverBaseContract
           ? universalReceiverBaseContractDeploymentReceipt$
           : EMPTY
@@ -59,26 +59,26 @@ function deployBaseContract$(contractName: ContractNames, deployContractFunction
 }
 
 export function getBaseContractAddresses$(
-  defaultLSP3BaseContractAddress: string,
+  defaultUPBaseContractAddress: string,
   defaultUniversalReceiverBaseContractAddress: string,
   defaultBaseContractByteCode$: Observable<[string, string]>,
   signer: Signer,
   contractDeploymentOptions?: ContractDeploymentOptions
 ) {
-  const providedLSP3BaseContractAddress = contractDeploymentOptions?.libAddresses?.lsp3AccountInit;
+  const providedUPBaseContractAddress = contractDeploymentOptions?.libAddresses?.erc725AccountInit;
   const providedUniversalReceiverContractAddress =
     contractDeploymentOptions?.libAddresses?.universalReceiverDelegateInit;
 
   const baseContractsToDeploy$ = defaultBaseContractByteCode$.pipe(
-    switchMap(([defaultLSP3BaseContractByteCode, defaultUniversalReceiverBaseContractByteCode]) => {
-      const shouldDeployLSP3BaseContract =
-        !providedLSP3BaseContractAddress && defaultLSP3BaseContractByteCode === '0x';
+    switchMap(([defaultUPBaseContractByteCode, defaultUniversalReceiverBaseContractByteCode]) => {
+      const shouldDeployUPBaseContract =
+        !providedUPBaseContractAddress && defaultUPBaseContractByteCode === '0x';
 
       const shouldDeployUniversalReceiverBaseContract =
         !providedUniversalReceiverContractAddress &&
         defaultUniversalReceiverBaseContractByteCode === '0x';
 
-      return of([shouldDeployLSP3BaseContract, shouldDeployUniversalReceiverBaseContract]);
+      return of([shouldDeployUPBaseContract, shouldDeployUniversalReceiverBaseContract]);
     })
   );
 
@@ -88,7 +88,7 @@ export function getBaseContractAddresses$(
   );
 
   const baseContractAddresses = {
-    [ContractNames.LSP3_ACCOUNT]: providedLSP3BaseContractAddress ?? defaultLSP3BaseContractAddress,
+    [ContractNames.ERC725_Account]: providedUPBaseContractAddress ?? defaultUPBaseContractAddress,
     [ContractNames.UNIVERSAL_RECEIVER]:
       providedUniversalReceiverContractAddress ?? defaultUniversalReceiverBaseContractAddress,
   };

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -45,8 +45,8 @@ export function accountDeployment$(
   signer: Signer,
   controllerAddresses: string[],
   baseContractAddresses$: Observable<{
-    LSP3Account: string;
-    UniversalReceiverDelegate: string;
+    [ContractNames.ERC725_Account]: string;
+    [ContractNames.UNIVERSAL_RECEIVER]: string;
   }>
 ) {
   return baseContractAddresses$.pipe(
@@ -54,7 +54,7 @@ export function accountDeployment$(
       return accountDeploymentWithBaseContractAddress$(
         signer,
         controllerAddresses,
-        baseContractAddresses.LSP3Account
+        baseContractAddresses.ERC725Account
       );
     }),
     shareReplay()
@@ -103,7 +103,7 @@ async function deployLSP3Account(
 
   return baseContractAddress
     ? deployProxyContract(deploymentFunction, signer)
-    : deployContract(deploymentFunction, ContractNames.LSP3_ACCOUNT);
+    : deployContract(deploymentFunction, ContractNames.ERC725_Account);
 }
 
 export async function deployProxyContract(
@@ -121,12 +121,12 @@ export async function deployProxyContract(
     const transaction = deployedProxy.deployTransaction;
     return {
       type: DeploymentType.PROXY,
-      contractName: ContractNames.LSP3_ACCOUNT,
+      contractName: ContractNames.ERC725_Account,
       status: DeploymentStatus.PENDING,
       transaction,
     };
   } catch (error) {
-    console.error(`Error when deploying ${ContractNames.LSP3_ACCOUNT}`, error);
+    console.error(`Error when deploying ${ContractNames.ERC725_Account}`, error);
     throw error;
   }
 }
@@ -252,7 +252,7 @@ export async function setData(
 
   return {
     type: DeploymentType.TRANSACTION,
-    contractName: ContractNames.LSP3_ACCOUNT,
+    contractName: ContractNames.ERC725_Account,
     functionName: 'setData',
     status: DeploymentStatus.PENDING,
     transaction,
@@ -300,7 +300,7 @@ export async function transferOwnership(
     return {
       type: DeploymentType.TRANSACTION,
       status: DeploymentStatus.PENDING,
-      contractName: ContractNames.LSP3_ACCOUNT,
+      contractName: ContractNames.ERC725_Account,
       functionName: 'transferOwnership',
       transaction,
     };

--- a/src/lib/services/universal-receiver.service.ts
+++ b/src/lib/services/universal-receiver.service.ts
@@ -26,8 +26,8 @@ export function universalReceiverDelegateDeployment$(
   signer: Signer,
   accountDeployment$: Observable<LSP3AccountDeploymentEvent>,
   baseContractDeployment$: Observable<{
-    LSP3Account: string;
-    UniversalReceiverDelegate: string;
+    [ContractNames.ERC725_Account]: string;
+    [ContractNames.UNIVERSAL_RECEIVER]: string;
   }>
 ) {
   return baseContractDeployment$.pipe(

--- a/src/versions.json
+++ b/src/versions.json
@@ -4,7 +4,7 @@
         "chainId": 22,
         "networkId": 22,
         "baseContracts": {
-            "LSP3Account": {
+            "ERC725Account": {
                 "0.0.1": "0x97fd63D049089cd70D9D139ccf9338c81372DE68"
             },
             "UniversalReceiverDelegate": {

--- a/test/deployment-events.mock.ts
+++ b/test/deployment-events.mock.ts
@@ -2,7 +2,7 @@ import { ContractNames, DeploymentStatus, DeploymentType } from '../src';
 
 const proxyDeploymentEventBase = {
   type: DeploymentType.PROXY,
-  contractName: ContractNames.LSP3_ACCOUNT,
+  contractName: ContractNames.ERC725_Account,
   status: DeploymentStatus.PENDING,
   transaction: {
     wait: async () => {
@@ -12,7 +12,7 @@ const proxyDeploymentEventBase = {
 };
 export const defaultDeploymentEvents = {
   [DeploymentType.PROXY]: {
-    [ContractNames.LSP3_ACCOUNT]: {
+    [ContractNames.ERC725_Account]: {
       deployment: {
         ...proxyDeploymentEventBase,
       },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- renames LSP3Account contracts ERC725Account to reflect contract upgrade

- **What is the current behavior?** (You can also link to an open issue here)
UP contract is referred to as LSP3Account

- **What is the new behavior (if this is a feature change)?**
UP contract is referred to ERC725Account

- **Other information**:
