### PR TITLE
chore: add KeyManager base/proxy deployment

### DIFF
--- a/src/versions.json
+++ b/src/versions.json
@@ -7,6 +7,9 @@
             "ERC725Account": {
                 "0.0.1": "0xe6009BCbC6cb1046E72db3b50Ff0b9F3C94Db2fB"
             },
+            "KeyManager": {
+                "0.0.1": "0x36C80542f7ed462cc3fdB2b7AC1a83A80C5dD0f6"
+            },
             "UniversalReceiverDelegate": {
                 "0.0.1": "0x6533158b042775e2FdFeF3cA1a782EFDbB8EB9b1"
             },


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Improvement

### What is the current behaviour (you can also link to an open issue here)?
KeyManager contracts are deployed as full contracts

### What is the new behaviour (if this is a feature change)?
Uses Proxy/base contract pattern to deploy KeyManager 

