### PR TITLE
docs: correct + improve deployment code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const myContracts = await lspFactory.LSP3UniversalProfile.deploy({
     },
   });
 
-const myUPAddress = myContracts.erc725Account.address;
+const myUPAddress = myContracts.ERC725Account.address;
 ```
 
 ### Using Deployment events

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ const myContracts = await lspFactory.LSP3UniversalProfile.deploy({
               width: 500,
               height: 500,
               hashFunction: "keccak256(bytes)",
-              hash: "0x...", // bytes32 hex string of the image hash
+              // bytes32 hex string of the image hash
+              hash: "0xfdafad027ecfe57eb4ad047b938805d1dec209d6e9f960fc320d7b9b11cbed14",
               url: "ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp",
             },
           ],
@@ -53,7 +54,8 @@ const myContracts = await lspFactory.LSP3UniversalProfile.deploy({
               width: 500,
               height: 500,
               hashFunction: "keccak256(bytes)",
-              hash: "0x...", // bytes32 hex string of the image hash
+              // bytes32 hex string of the image hash
+              hash: "0xfdafad027ecfe57eb4ad047b938805d1dec209d6e9f960fc320d7b9b11cbed14",
               url: "ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp",
             },
           ],

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ const myContracts = await lspFactory.LSP3UniversalProfile.deploy({
       url: "",
     },
   });
-};
 
 const myUPAddress = myContracts.erc725Account.address;
 ```


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

docs update

### What is the current behaviour (you can also link to an open issue here)?

When using the code example from the README to deploy a Universal Profile, several errors occur:

- syntax error due to extra curly brace at the end.
- incorrect property name to obtain UP address
- cannot deploy because missing keccak256 checksum of profile + background images

### What is the new behaviour (if this is a feature change)?

All the errors in the deployment code snippet mentioned above are fixed.

Anyone can now copy-paste the code snippet from the README to deploy + create a UP easily ✅ 

### Other information:
