### PR TITLE
fix: add zero-left padding for `AddressPermissions[]` length

### DIFF
--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -282,7 +282,7 @@ export async function setData(
     universalReceiverDelegateAddress,
     signerPermissions ?? ALL_PERMISSIONS,
     SET_DATA_PERMISSION,
-    ethers.utils.hexZeroPad(2, 32),
+    ethers.utils.hexZeroPad('0x02', 32),
     controllerAddress,
     universalReceiverDelegateAddress,
   ];

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -1,6 +1,6 @@
 import { TransactionReceipt } from '@ethersproject/providers';
 import axios from 'axios';
-import { BytesLike, Contract, ContractFactory, Signer, ethers } from 'ethers';
+import { BytesLike, Contract, ContractFactory, ethers, Signer } from 'ethers';
 import { concat, defer, EMPTY, forkJoin, from, Observable, of } from 'rxjs';
 import { shareReplay, switchMap } from 'rxjs/operators';
 

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -1,6 +1,6 @@
 import { TransactionReceipt } from '@ethersproject/providers';
 import axios from 'axios';
-import { BytesLike, Contract, ContractFactory, Signer } from 'ethers';
+import { BytesLike, Contract, ContractFactory, Signer, ethers } from 'ethers';
 import { concat, defer, EMPTY, forkJoin, from, Observable, of } from 'rxjs';
 import { shareReplay, switchMap } from 'rxjs/operators';
 
@@ -282,7 +282,7 @@ export async function setData(
     universalReceiverDelegateAddress,
     signerPermissions ?? ALL_PERMISSIONS,
     SET_DATA_PERMISSION,
-    2,
+    ethers.utils.hexZeroPad(2, 32),
     controllerAddress,
     universalReceiverDelegateAddress,
   ];


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Bug Fix.

### What is the current behaviour (you can also link to an open issue here)?

When deploying a Universal Profile with the lsp-factory, the key `AddressPermissions[]` (number of addresses that have a permission set on the UP) is set to `0x02`. ❌ 

This makes [erc725.js](https://github.com/ERC725Alliance/erc725.js) to not work when trying to fetch all the array elements.

### What is the new behaviour (if this is a feature change)?

[LSP2 - ERC725Y JSON Schema](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#example) defines that for any ERC725Y key of type Array, the length value should be stored as a `uint256`, left zero padded.

So fix this bug by setting the array length to `0x0000000000000000000000000000000000000000000000000000000000000002` ✅ 