### PR TITLE
feature: allow passing custom bytecode

### DIFF
--- a/docs/deployment/contract-deployment-options.md
+++ b/docs/deployment/contract-deployment-options.md
@@ -14,9 +14,9 @@ The `deploy` function takes an object `contractDeploymentOptions` as its second 
 - `deployProxy?` - `boolean`: Whether the contract should be deployed using a proxy contract implementation (eg: [EIP1167](https://eips.ethereum.org/EIPS/eip-1167)). Defaults to true.
 - `libAddress?` - `string`: The Address of a Base Contract to be used in deployment as implementation behind a proxy contract (eg: [EIP1167](https://eips.ethereum.org/EIPS/eip-1167)).
 
-This is an optional parameter and so may be omitted. If no contract deployment options are specified, `LSPFactory` will deploy a proxy contract which defers to a base contract implementation as per the [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) standard.
+This is an optional parameter and so may be omitted. If no contract deployment options are specified, `LSPFactory` will deploy a **minimal proxy contract** based on the [EIP1167](https://eips.ethereum.org/EIPS/eip-1167. The proxy contract will reference the address of a base contract implementation already deployed on the network.
 
-If you do not want your contract to use proxy deployment you can set `deployProxy` to `false`. This will deploy a 'full' contract with constructor rather than using a proxy deployment with initializer.
+If you do not want your contract to use proxy deployment you can set `deployProxy` to `false`. This will deploy a 'full' contract with a constructor rather than using a proxy deployment with initializer.
 
 :::info Info
 LSPFactory stores base contract addresses for different versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json) and uses the latest available version if no version is specified.
@@ -24,27 +24,15 @@ LSPFactory stores base contract addresses for different versions [internally](ht
 
 #### Custom Bytecode
 
-You can specify the bytecode you want your contract to use by providing the `byteCode` parameter. Unless `deployProxy` is set to `false`, LSPFactory will deploy a proxy contract which will defer to a base contract where your bytecode is deployed.
+You can specify the bytecode you want your contract to use by providing the `byteCode` parameter. This will deploy a full contract from your custom bytecode without using a proxy.
 
-For example, you could deploy a Universal Profile with a KeyManager which uses your custom bytecode as a base contract implementation:
+For example, you could deploy a Universal Profile with a Key Manager which uses your custom bytecode:
 
-```javascript title="Deploying a Universal Profile with a custom KeyManager base contract"
+```javascript title="Deploying a Universal Profile with a custom Key Manager base contract"
 lspFactory.LSP3UniversalProfile.deploy({...}, {
     version: '0.4.1'
     KeyManager: {
         bytecode: '0x...',
-    }
-})
-```
-
-Or if you want to use your custom bytecode for the KeyManager contract itself (rather than for a base contract behind a proxy), you can set deployProxy to `false`:
-
-```javascript title="Deploying a Universal Profile with a custom KeyManager base contract"
-lspFactory.LSP3UniversalProfile.deploy({...}, {
-    version: '0.4.1'
-    KeyManager: {
-        bytecode: '0x...',
-        deployProxy: false
     }
 })
 ```

--- a/docs/deployment/contract-deployment-options.md
+++ b/docs/deployment/contract-deployment-options.md
@@ -14,10 +14,9 @@ The `deploy` function takes an object `contractDeploymentOptions` as its second 
 - `deployProxy?` - `boolean`: Whether the contract should be deployed using a proxy contract implementation (eg: [EIP1167](https://eips.ethereum.org/EIPS/eip-1167)). Defaults to true.
 - `libAddress?` - `string`: The Address of a Base Contract to be used in deployment as implementation behind a proxy contract (eg: [EIP1167](https://eips.ethereum.org/EIPS/eip-1167)).
 
+This is an optional parameter and so may be omitted. If no contract deployment options are specified, `LSPFactory` will deploy a proxy contract which defers to a base contract implementation as per the [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) standard.
 
-This is an optional parameter and so may be ommitted. If no contract deployment options are specified, `LSPFactory` will deploy a proxy contract which defers to a base contract implementation as per the [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) standard.
-
-If you do not want your contract to use proxy deployment you can set `deployProxy` to `false`. This will deploy a 'full' contract rather than using a proxy deployment.
+If you do not want your contract to use proxy deployment you can set `deployProxy` to `false`. This will deploy a 'full' contract with constructor rather than using a proxy deployment with initializer.
 
 :::info Info
 LSPFactory stores base contract addresses for different versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json) and uses the latest available version if no version is specified.
@@ -25,7 +24,7 @@ LSPFactory stores base contract addresses for different versions [internally](ht
 
 #### Custom Bytecode
 
-By passing the `bytecode` parameter you can specify the bytecode you want your contract to use. Unless `deployProxy` is set to `false`, LSPFactory will deploy a proxy contract which will defer to a base contract where your bytecode is deployed.
+You can specify the bytecode you want your contract to use by providing the `byteCode` parameter. Unless `deployProxy` is set to `false`, LSPFactory will deploy a proxy contract which will defer to a base contract where your bytecode is deployed.
 
 For example, you could deploy a Universal Profile with a KeyManager which uses your custom bytecode as a base contract implementation:
 
@@ -38,7 +37,7 @@ lspFactory.LSP3UniversalProfile.deploy({...}, {
 })
 ```
 
-Or if you want your custom bytecode to be deployed at the KeyManager contract itself rather than at the base contract implementation you can set `deployProxy` to false:
+Or if you want to use your custom bytecode for the KeyManager contract itself (rather than for a base contract behind a proxy), you can set deployProxy to `false`:
 
 ```javascript title="Deploying a Universal Profile with a custom KeyManager base contract"
 lspFactory.LSP3UniversalProfile.deploy({...}, {
@@ -62,7 +61,7 @@ lspFactory.LSP3UniversalProfile.deploy({...}, {
 
 <!-- :::info Infos -->
 
-**LSPFactory also allows contracts to be individually customisable. You can set the version per contract which will take presidence over the global version:**
+**LSPFactory also allows contracts to be individually customisable. You can set the version per contract which will take precedence over the global version:**
 
 <!-- ::: -->
 

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -12,7 +12,11 @@ import {
   UniversalProfile__factory,
 } from '../../../build/main/src';
 import { LSPFactory } from '../../../build/main/src/lib/lsp-factory';
-import { testSetData, testUPDeployment } from '../../../test/test.utils';
+import {
+  testProxyBytecodeContainsAddress,
+  testSetData,
+  testUPDeployment,
+} from '../../../test/test.utils';
 import {
   ADDRESS_PERMISSIONS_ARRAY_KEY,
   DEFAULT_PERMISSIONS,
@@ -68,7 +72,7 @@ describe('LSP3UniversalProfile', () => {
 
   describe('Deploying a UP with one controller address', () => {
     let uniqueController: SignerWithAddress;
-    let universalProfile: SignerWithAddress;
+    let universalProfile;
 
     beforeAll(async () => {
       uniqueController = signers[0];
@@ -234,8 +238,9 @@ describe('LSP3UniversalProfile', () => {
     });
 
     describe('Deployment with only ERC725 baseContract set to true', () => {
+      let deployedContracts: DeployedContracts;
       it('Should deploy only ERC725 Base contract', async () => {
-        await testUPDeployment(
+        deployedContracts = await testUPDeployment(
           {
             ERC725Account: { deployProxy: true },
             KeyManager: { deployProxy: false },
@@ -246,11 +251,19 @@ describe('LSP3UniversalProfile', () => {
           [signers[0].address]
         );
       });
+      it('UP contract bytecode should contain base contract address', async () => {
+        await testProxyBytecodeContainsAddress(
+          deployedContracts.ERC725Account.address,
+          deployedContracts.ERC725AccountBaseContract.address,
+          provider
+        );
+      });
     });
 
     describe('Deployment with only KeyManager baseContract set to true', () => {
+      let deployedContracts: DeployedContracts;
       it('Should deploy only KeyManager Base contract', async () => {
-        await testUPDeployment(
+        deployedContracts = await testUPDeployment(
           {
             ERC725Account: { deployProxy: false },
             KeyManager: { deployProxy: true },
@@ -261,11 +274,19 @@ describe('LSP3UniversalProfile', () => {
           [signers[0].address]
         );
       });
+      it('KeyManager contract bytecode should contain base contract address', async () => {
+        await testProxyBytecodeContainsAddress(
+          deployedContracts.KeyManager.address,
+          deployedContracts.KeyManagerBaseContract.address,
+          provider
+        );
+      });
     });
 
     describe('Deployment with only URD baseContract set to true', () => {
+      let deployedContracts: DeployedContracts;
       it('Should deploy only URD Base contract', async () => {
-        await testUPDeployment(
+        deployedContracts = await testUPDeployment(
           {
             ERC725Account: { deployProxy: false },
             KeyManager: { deployProxy: false },
@@ -274,6 +295,14 @@ describe('LSP3UniversalProfile', () => {
           4,
           lspFactory,
           [signers[0].address]
+        );
+      });
+
+      it('KeyManager contract bytecode should contain base contract address', async () => {
+        await testProxyBytecodeContainsAddress(
+          deployedContracts.UniversalReceiverDelegate.address,
+          deployedContracts.UniversalReceiverDelegateBaseContract.address,
+          provider
         );
       });
     });
@@ -384,12 +413,18 @@ describe('LSP3UniversalProfile', () => {
           [signers[0].address]
         );
       });
-
       it('should be able to setData', async () => {
         await testSetData(
           deployedContracts.ERC725Account.address,
           deployedContracts.KeyManager.address,
           signers[0]
+        );
+      });
+      it('UP contract bytecode should contain base contract address', async () => {
+        await testProxyBytecodeContainsAddress(
+          deployedContracts.ERC725Account.address,
+          baseContracts.universalProfile.address,
+          provider
         );
       });
     });
@@ -407,12 +442,18 @@ describe('LSP3UniversalProfile', () => {
           [signers[0].address]
         );
       });
-
       it('should be able to setData', async () => {
         await testSetData(
           deployedContracts.ERC725Account.address,
           deployedContracts.KeyManager.address,
           signers[0]
+        );
+      });
+      it('UP contract bytecode should contain base contract address', async () => {
+        await testProxyBytecodeContainsAddress(
+          deployedContracts.KeyManager.address,
+          baseContracts.keyManager.address,
+          provider
         );
       });
     });

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -66,7 +66,8 @@ export class LSP7DigitalAsset {
       this.options.provider,
       deployProxy,
       defaultBaseContractAddress,
-      contractDeploymentOptions?.libAddress
+      contractDeploymentOptions?.libAddress,
+      contractDeploymentOptions?.byteCode
     );
 
     const baseContractDeployment$ = deployBaseContract$.pipe(
@@ -79,13 +80,15 @@ export class LSP7DigitalAsset {
     const baseContractAddress$ = waitForBaseContractAddress$(
       baseContractDeployment$,
       defaultBaseContractAddress,
-      deployProxy
+      deployProxy,
+      contractDeploymentOptions?.byteCode
     );
 
     const digitalAsset$ = lsp7DigitalAssetDeployment$(
       this.signer,
       digitalAssetDeploymentOptions,
-      baseContractAddress$
+      baseContractAddress$,
+      contractDeploymentOptions?.byteCode
     );
 
     const deployment$ = concat([baseContractDeployment$, digitalAsset$]).pipe(concatAll());

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -1,3 +1,4 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { providers } from 'ethers';
 import { ethers } from 'hardhat';
 import { Observable } from 'rxjs';
@@ -13,7 +14,7 @@ jest.useRealTimers();
 describe('LSP7DigitalAsset', () => {
   let baseContract;
   let proxyDeployer: ProxyDeployer;
-  let signer;
+  let signer: SignerWithAddress;
   let provider: providers.JsonRpcProvider;
 
   beforeAll(async () => {

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -140,4 +140,44 @@ describe('LSP7DigitalAsset', () => {
       },
     });
   });
+
+  it('should deploy lsp7 with custom bytecode', async () => {
+    const lspFactory = new LSPFactory(provider, signer);
+
+    const passedBytecode = LSP7Mintable__factory.bytecode;
+
+    const lsp7DigitalAsset = (await lspFactory.LSP7DigitalAsset.deploy(
+      {
+        controllerAddress: signer.address,
+        isNFT: false,
+        name: 'TOKEN',
+        symbol: 'TKN',
+      },
+      {
+        byteCode: passedBytecode,
+      }
+    )) as DeployedLSP7DigitalAsset;
+
+    expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
+    expect(Object.keys(lsp7DigitalAsset).length).toEqual(1);
+
+    const LSP7DigitalAsset = LSP7Mintable__factory.connect(
+      lsp7DigitalAsset.LSP7DigitalAsset.address,
+      signer
+    );
+
+    const ownerAddress = await LSP7DigitalAsset.owner();
+    expect(ownerAddress).toEqual(signer.address);
+
+    const mintBalance = 10;
+    const mintAddress = '0x1da537A8D1979b25794FB07d694119574f4f46Cf';
+
+    const mint = await LSP7DigitalAsset.mint(mintAddress, mintBalance, true, '0x');
+
+    expect(mint).toBeTruthy();
+    await mint.wait();
+
+    const actualMintBalance = (await LSP7DigitalAsset.balanceOf(mintAddress)).toNumber();
+    expect(actualMintBalance).toEqual(mintBalance);
+  });
 });

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -65,7 +65,8 @@ export class LSP8IdentifiableDigitalAsset {
       this.options.provider,
       deployProxy,
       defaultBaseContractAddress,
-      contractDeploymentOptions?.libAddress
+      contractDeploymentOptions?.libAddress,
+      contractDeploymentOptions?.byteCode
     );
 
     const baseContractDeployment$ = deployBaseContract$.pipe(
@@ -78,13 +79,15 @@ export class LSP8IdentifiableDigitalAsset {
     const baseContractAddress$ = waitForBaseContractAddress$(
       baseContractDeployment$,
       defaultBaseContractAddress,
-      deployProxy
+      deployProxy,
+      contractDeploymentOptions?.byteCode
     );
 
     const digitalAsset$ = lsp8IdentifiableDigitalAssetDeployment$(
       this.signer,
       digitalAssetDeploymentOptions,
-      baseContractAddress$
+      baseContractAddress$,
+      contractDeploymentOptions?.byteCode
     );
 
     const deployment$ = concat([baseContractDeployment$, digitalAsset$]).pipe(concatAll());

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -1,3 +1,4 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { providers } from 'ethers';
 import { ethers } from 'hardhat';
 import { Observable } from 'rxjs';
@@ -13,7 +14,7 @@ jest.useRealTimers();
 describe('LSP8IdentifiableDigitalAsset', () => {
   let baseContract;
   let proxyDeployer: ProxyDeployer;
-  let signer;
+  let signer: SignerWithAddress;
   let provider: providers.JsonRpcProvider;
 
   beforeAll(async () => {

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -174,4 +174,50 @@ describe('LSP8IdentifiableDigitalAsset', () => {
       },
     });
   });
+
+  it('should deploy lsp8 with custom bytecode', async () => {
+    const lspFactory = new LSPFactory(provider, signer);
+
+    const passedBytecode = LSP8Mintable__factory.bytecode;
+
+    const lsp8IdentifiableDigitalAsset = (await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
+      {
+        controllerAddress: signer.address,
+        name: 'TOKEN',
+        symbol: 'TKN',
+      },
+      {
+        byteCode: passedBytecode,
+      }
+    )) as DeployedLSP8IdentifiableDigitalAsset;
+
+    expect(lsp8IdentifiableDigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
+    expect(Object.keys(lsp8IdentifiableDigitalAsset).length).toEqual(1);
+
+    const LSP8IdentifiableDigitalAsset = LSP8Mintable__factory.connect(
+      lsp8IdentifiableDigitalAsset.LSP8IdentifiableDigitalAsset.address,
+      signer
+    );
+
+    const ownerAddress = await LSP8IdentifiableDigitalAsset.owner();
+    expect(ownerAddress).toEqual(signer.address);
+
+    const mintAddress = '0x1da537A8D1979b25794FB07d694119574f4f46Cf';
+
+    const mint = await LSP8IdentifiableDigitalAsset.mint(
+      mintAddress,
+      ethers.utils.hexZeroPad(ethers.utils.hexlify(1), 32),
+      true,
+      '0x'
+    );
+
+    expect(mint).toBeTruthy();
+    await mint.wait();
+
+    const actualMintBalance = (
+      await LSP8IdentifiableDigitalAsset.balanceOf(mintAddress)
+    ).toNumber();
+
+    expect(actualMintBalance).toEqual(1);
+  });
 });

--- a/src/lib/services/base-contract.service.ts
+++ b/src/lib/services/base-contract.service.ts
@@ -190,17 +190,20 @@ export function universalProfileBaseContractAddresses$(
   const baseContractAddresses: BaseContractAddresses = {
     [UniversalProfileContractNames.ERC725_Account]:
       providedUPBaseContractAddress ??
-      contractDeploymentOptions?.ERC725Account?.deployProxy !== false
+      (contractDeploymentOptions?.ERC725Account?.deployProxy !== false &&
+        !contractDeploymentOptions?.ERC725Account?.byteCode)
         ? defaultUPBaseContractAddress
         : null,
     [UniversalProfileContractNames.UNIVERSAL_RECEIVER]:
       providedUniversalReceiverContractAddress ??
-      contractDeploymentOptions?.UniversalReceiverDelegate?.deployProxy !== false
+      (contractDeploymentOptions?.UniversalReceiverDelegate?.deployProxy !== false &&
+        !contractDeploymentOptions?.UniversalReceiverDelegate?.byteCode)
         ? defaultUniversalReceiverBaseContractAddress
         : null,
     [UniversalProfileContractNames.KEY_MANAGER]:
       providedKeyManagerContractAddress ??
-      contractDeploymentOptions?.KeyManager?.deployProxy !== false
+      (contractDeploymentOptions?.KeyManager?.deployProxy !== false &&
+        !contractDeploymentOptions?.KeyManager?.byteCode)
         ? defaultKeyManagerBaseContractAddress
         : null,
   };

--- a/src/lib/services/base-contract.service.ts
+++ b/src/lib/services/base-contract.service.ts
@@ -126,12 +126,12 @@ export function shouldDeployBaseContract$(
   );
 
   return defaultBaseContractBytecode$.pipe(
-    switchMap((defultBaseContractBytecode) => {
+    switchMap((defaultBaseContractBytecode) => {
       return of(
         !providedBaseContractAddress &&
           !providedByteCode &&
           deployProxy &&
-          defultBaseContractBytecode === '0x'
+          defaultBaseContractBytecode === '0x'
       );
     }),
     shareReplay()

--- a/src/lib/services/lsp3-account.service.spec.ts
+++ b/src/lib/services/lsp3-account.service.spec.ts
@@ -1,5 +1,6 @@
 import ERC725 from '@erc725/erc725.js';
-import { ethers, SignerWithAddress } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
 
 import { deployUniversalProfileContracts } from '../../../test/test.utils';
 import {

--- a/test/test.utils.ts
+++ b/test/test.utils.ts
@@ -8,6 +8,8 @@ import { LSP6KeyManager__factory } from '../types/ethers-v5/factories/LSP6KeyMan
 import { LSP1UniversalReceiverDelegate__factory } from '../types/ethers-v5/factories/LSP1UniversalReceiverDelegate__factory';
 import { ContractDeploymentOptions, LSPFactory } from '../build/main/src';
 import { DeployedContracts } from '../src/lib/interfaces';
+import { getDeployedByteCode, getProxyByteCode } from '../src/lib/helpers/deployment.helper';
+import { providers } from 'ethers';
 
 export async function deployUniversalProfileContracts(signer: Signer, owner: string) {
   let nonceManager = new NonceManager(signer);
@@ -73,4 +75,14 @@ export async function testSetData(upAddress: string, keyManagerAddress: string, 
 
   const data = await universalProfile.getData([key]);
   expect(data).toEqual([value]);
+}
+
+export async function testProxyBytecodeContainsAddress(
+  proxyAddress: string,
+  baseContractAddress: string,
+  provider: providers.Web3Provider | providers.JsonRpcProvider
+) {
+  const bytecode = await getDeployedByteCode(proxyAddress, provider);
+
+  expect(bytecode).toContain(baseContractAddress.slice(0, 2));
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Feature

### What is the new behaviour (if this is a feature change)?
Enable deploying contracts with custom provided bytecode.

### Other information:
Requirement for now is to deploy full contract if custom bytecode is passed without proxy deployment. In future we may want to allow passing custom bytecode to be deployed as the base contract