### PR TITLE
chore: reuse URD address between UPs

### DIFF
--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -72,11 +72,10 @@ export class LSP7DigitalAsset {
         contractDeploymentOptions?.version ?? DEFAULT_CONTRACT_VERSION
       ];
 
-    const deployProxy = contractDeploymentOptions?.deployProxy === false ? false : true;
-
     const deployBaseContract$ = shouldDeployBaseContract$(
       this.options.provider,
-      deployProxy,
+      versions[this.options.chainId]?.contracts.LSP7Mintable?.baseContract,
+      contractDeploymentOptions?.deployProxy,
       defaultBaseContractAddress,
       contractDeploymentOptions?.libAddress,
       contractDeploymentOptions?.byteCode
@@ -92,7 +91,7 @@ export class LSP7DigitalAsset {
     const baseContractAddress$ = waitForBaseContractAddress$(
       baseContractDeployment$,
       defaultBaseContractAddress,
-      deployProxy,
+      contractDeploymentOptions?.deployProxy,
       contractDeploymentOptions?.byteCode
     );
 

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -71,11 +71,10 @@ export class LSP8IdentifiableDigitalAsset {
         contractDeploymentOptions?.version ?? DEFAULT_CONTRACT_VERSION
       ];
 
-    const deployProxy = contractDeploymentOptions?.deployProxy === false ? false : true;
-
     const deployBaseContract$ = shouldDeployBaseContract$(
       this.options.provider,
-      deployProxy,
+      versions[this.options.chainId]?.contracts.LSP8Mintable?.baseContract,
+      contractDeploymentOptions?.deployProxy,
       defaultBaseContractAddress,
       contractDeploymentOptions?.libAddress,
       contractDeploymentOptions?.byteCode
@@ -91,7 +90,7 @@ export class LSP8IdentifiableDigitalAsset {
     const baseContractAddress$ = waitForBaseContractAddress$(
       baseContractDeployment$,
       defaultBaseContractAddress,
-      deployProxy,
+      contractDeploymentOptions?.deployProxy,
       contractDeploymentOptions?.byteCode
     );
 

--- a/src/versions.json
+++ b/src/versions.json
@@ -13,7 +13,7 @@
         "baseContract": true
       },
       "UniversalReceiverDelegate": {
-        "versions": { "0.0.1": "0x6533158b042775e2FdFeF3cA1a782EFDbB8EB9b1" },
+        "versions": { "0.0.1": "0xEE495c349eB1ae864bb0e899A71aBD0b660eE4f0" },
         "baseContract": false
       },
       "LSP7Mintable": {

--- a/test/test.utils.ts
+++ b/test/test.utils.ts
@@ -43,7 +43,7 @@ export async function testUPDeployment(
 
   expect(Object.keys(deployedContracts).length).toEqual(expectedContractNumber);
 
-  const contractNames = ['ERC725Account', 'KeyManager', 'UniversalReceiverDelegate'];
+  const contractNames = ['ERC725Account', 'KeyManager'];
 
   for (const contractName of contractNames) {
     if (
@@ -55,6 +55,15 @@ export async function testUPDeployment(
     } else {
       expect(deployedContracts[`${contractName}BaseContract`]).toBeDefined();
     }
+  }
+
+  if (
+    contractDeploymentOptions.UniversalReceiverDelegate?.deployProxy &&
+    !contractDeploymentOptions.UniversalReceiverDelegate.libAddress
+  ) {
+    expect(deployedContracts[`UniversalReceiverDelegateBaseContract`]).toBeDefined();
+  } else {
+    expect(deployedContracts[`UniversalReceiverDelegateBaseContract`]).toBeUndefined();
   }
 
   return deployedContracts as DeployedContracts;


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
improvement

### What is the current behaviour (you can also link to an open issue here)?
Deploys a new Universal Receiver Delegate contract for every UP deployment

### What is the new behaviour (if this is a feature change)?
Reuse the default URD contract for all UPS

### Other information:
User can specify a custom URD address, or if a URD contract should be deployed by using 'deployProxy' key.
