### PR TITLE
chore: set LSP4Creators[] when deploying digital assets

### DIFF
--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -24,7 +24,7 @@ Deploys a mintable [LSP7 Digital Asset](../../../standards/nft-2.0/LSP7-Digital-
    - `ownerAddress` - `string` : The owner of the contract.
    - `isNFT` - `boolean`: Specify if the contract represent a fungible or a non-fungible token.
    - `digitalAssetMetadata`?: `LSP4MetadataBeforeUpload | string`: [LSP4 Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md) to be attached to the smart contract. Can be an encoded hex string, ipfs url or metadata object as defined in (LSP4DigitalAssetMetadata.uploadMetadata)[./lsp4-digital-asset-metadata#uploadMetadata].
-   - `creators?` `string[]`: Array of ERC725Accounnt Addresses that defines the creators of the digital asset. Used to set the [LSP4Creators[]](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4creators) key on the contract.
+   - `creators?` `string[]`: Array of ERC725Account `address`es that defines the creators of the digital asset. Used to set the [LSP4Creators[]](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4creators) key on the contract.
 2. `contractDeploymentOptions?` - `Object`: Specify contract deployment details. See [Contract Deployment Options specification](../deployment/contract-deployment-options) for more information.
     - `version?` - `string`: The contract version you want to deploy. Defaults to latest version of [lsp-smart-contracts library](https://github.com/lukso-network/lsp-smart-contracts).
     - `byteCode?` - `string`: The creation + runtime bytecode of the contract to deploy.

--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -24,6 +24,7 @@ Deploys a mintable [LSP7 Digital Asset](../../../standards/nft-2.0/LSP7-Digital-
    - `ownerAddress` - `string` : The owner of the contract.
    - `isNFT` - `boolean`: Specify if the contract represent a fungible or a non-fungible token.
    - `digitalAssetMetadata`?: `LSP4MetadataBeforeUpload | string`: [LSP4 Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md) to be attached to the smart contract. Can be an encoded hex string, ipfs url or metadata object as defined in (LSP4DigitalAssetMetadata.uploadMetadata)[./lsp4-digital-asset-metadata#uploadMetadata].
+   - `creators?` `string[]`: Array of ERC725Accounnt Addresses that defines the creators of the digital asset. Used to set the [LSP4Creators[]](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4creators) key on the contract.
 2. `contractDeploymentOptions?` - `Object`: Specify contract deployment details. See [Contract Deployment Options specification](../deployment/contract-deployment-options) for more information.
     - `version?` - `string`: The contract version you want to deploy. Defaults to latest version of [lsp-smart-contracts library](https://github.com/lukso-network/lsp-smart-contracts).
     - `byteCode?` - `string`: The creation + runtime bytecode of the contract to deploy.

--- a/docs/classes/lsp8-identifiable-digital-asset.md
+++ b/docs/classes/lsp8-identifiable-digital-asset.md
@@ -22,6 +22,7 @@ Deploys a mintable [LSP8 Identifiable Digital Asset](../../../standards/nft-2.0/
    - `symbol` - `string`: The symbol of the token.
    - `ownerAddress` - `string` : The owner of the contract.
    - `digitalAssetMetadata`?: `LSP4MetadataBeforeUpload | string`: [LSP4 Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md) to be attached to the smart contract. Can be an encoded hex string, ipfs url or metadata object as defined in (LSP4DigitalAssetMetadata.uploadMetadata)[./lsp4-digital-asset-metadata#uploadMetadata].
+   - `creators?` `string[]`: Array of ERC725Accounnt Addresses that defines the creators of the digital asset. Used to set the [LSP4Creators[]](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4creators) key on the contract.
 2. `contractDeploymentOptions?` - `Object`: Same as for [LSP7DigitalAsset deployment](./lsp7-digital-asset)
 
 #### Returns
@@ -82,7 +83,7 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
     symbol: 'TKN',
     ownerAddress: '0xb74a88C43BCf691bd7A851f6603cb1868f6fc147',
   },
-  { deployReactive: true },
+  { deployReactive: true }
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);

--- a/docs/classes/lsp8-identifiable-digital-asset.md
+++ b/docs/classes/lsp8-identifiable-digital-asset.md
@@ -22,7 +22,7 @@ Deploys a mintable [LSP8 Identifiable Digital Asset](../../../standards/nft-2.0/
    - `symbol` - `string`: The symbol of the token.
    - `ownerAddress` - `string` : The owner of the contract.
    - `digitalAssetMetadata`?: `LSP4MetadataBeforeUpload | string`: [LSP4 Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md) to be attached to the smart contract. Can be an encoded hex string, ipfs url or metadata object as defined in (LSP4DigitalAssetMetadata.uploadMetadata)[./lsp4-digital-asset-metadata#uploadMetadata].
-   - `creators?` `string[]`: Array of ERC725Accounnt Addresses that defines the creators of the digital asset. Used to set the [LSP4Creators[]](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4creators) key on the contract.
+   - `creators?` `string[]`: Array of ERC725Account `address`es that defines the creators of the digital asset. Used to set the [LSP4Creators[]](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4creators) key on the contract.
 2. `contractDeploymentOptions?` - `Object`: Same as for [LSP7DigitalAsset deployment](./lsp7-digital-asset)
 
 #### Returns

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -100,7 +100,6 @@ export class LSP7DigitalAsset {
       this.signer,
       digitalAssetDeploymentOptions,
       baseContractAddress$,
-      lsp4Metadata$,
       contractDeploymentOptions?.byteCode
     );
 

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -10,7 +10,7 @@ import {
   LSPFactory,
 } from '../../../build/main/src/index';
 import { DeployedLSP7DigitalAsset } from '../../../build/main/src/lib/interfaces/digital-asset-deployment';
-import { LSP4_KEYS } from '../helpers/config.helper';
+import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 
 import { lsp4DigitalAsset } from './../../../test/lsp4-digital-asset.mock';
 import { ProxyDeployer } from './proxy-deployer';
@@ -277,6 +277,19 @@ describe('LSP7DigitalAsset', () => {
 
       expect(ethers.utils.getAddress(creator1)).toEqual(creators[0]);
       expect(ethers.utils.getAddress(creator2)).toEqual(creators[1]);
+    });
+    it('should have LSP4CreatorsMap set correctly', async () => {
+      const creatorMap = await digitalAsset.getData([
+        LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[0].slice(2),
+        LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[1].slice(2),
+      ]);
+
+      expect(creatorMap[0]).toEqual(
+        ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
+      );
+      expect(creatorMap[1]).toEqual(
+        ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
+      );
     });
   });
 });

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -10,6 +10,7 @@ import {
   LSPFactory,
 } from '../../../build/main/src/index';
 import { DeployedLSP7DigitalAsset } from '../../../build/main/src/lib/interfaces/digital-asset-deployment';
+import { LSP4_KEYS } from '../helpers/config.helper';
 
 import { lsp4DigitalAsset } from './../../../test/lsp4-digital-asset.mock';
 import { ProxyDeployer } from './proxy-deployer';
@@ -230,6 +231,52 @@ describe('LSP7DigitalAsset', () => {
 
       expect(ethers.utils.toUtf8String(retrievedName)).toEqual(name);
       expect(ethers.utils.toUtf8String(retrievedSymbol)).toEqual(symbol);
+    });
+  });
+  describe('deploy lsp7 with specified creators', () => {
+    let digitalAsset: LSP7Mintable;
+    const controllerAddress = '0xaDa25A4424b08F5337DacD619D4bCb21536a9B95';
+    const name = 'TOKEN';
+    const symbol = 'TKN';
+    const isNFT = true;
+    const creators = [
+      '0xFCA72D5763b8cFc686C2285099D5F35a2F094E9f',
+      '0x591c236982b089Ad4B60758C075fA50Ec53CD674',
+    ];
+
+    it('should deploy with specified creators', async () => {
+      const lspFactory = new LSPFactory(provider, signer);
+      const lsp7DigitalAsset = (await lspFactory.LSP7DigitalAsset.deploy({
+        controllerAddress,
+        name,
+        symbol,
+        creators,
+        isNFT,
+      })) as DeployedLSP7DigitalAsset;
+
+      expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
+      expect(Object.keys(lsp7DigitalAsset).length).toEqual(2);
+
+      digitalAsset = LSP7Mintable__factory.connect(
+        lsp7DigitalAsset.LSP7DigitalAsset.address,
+        signer
+      );
+    });
+    it('should have LSP4Creators[] set correctly', async () => {
+      const [creatorArrayLength] = await digitalAsset.getData([LSP4_KEYS.LSP4_CREATORS_ARRAY]);
+      expect(creatorArrayLength).toEqual(
+        '0x0000000000000000000000000000000000000000000000000000000000000002'
+      );
+
+      const [creator1, creator2] = await digitalAsset.getData([
+        LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
+          ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 16).substring(2),
+        LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
+          ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 16).substring(2),
+      ]);
+
+      expect(ethers.utils.getAddress(creator1)).toEqual(creators[0]);
+      expect(ethers.utils.getAddress(creator2)).toEqual(creators[1]);
     });
   });
 });

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -99,7 +99,6 @@ export class LSP8IdentifiableDigitalAsset {
       this.signer,
       digitalAssetDeploymentOptions,
       baseContractAddress$,
-      lsp4Metadata$,
       contractDeploymentOptions?.byteCode
     );
 

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../build/main/src/index';
 import { DeployedLSP8IdentifiableDigitalAsset } from '../../../build/main/src/lib/interfaces/digital-asset-deployment';
 import { lsp4DigitalAsset } from '../../../test/lsp4-digital-asset.mock';
-import { LSP4_KEYS } from '../helpers/config.helper';
+import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 
 import { ProxyDeployer } from './proxy-deployer';
 
@@ -314,6 +314,19 @@ describe('LSP8IdentifiableDigitalAsset', () => {
 
       expect(ethers.utils.getAddress(creator1)).toEqual(creators[0]);
       expect(ethers.utils.getAddress(creator2)).toEqual(creators[1]);
+    });
+    it('should have LSP4CreatorsMap set correctly', async () => {
+      const creatorMap = await digitalAsset.getData([
+        LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[0].slice(2),
+        LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[1].slice(2),
+      ]);
+
+      expect(creatorMap[0]).toEqual(
+        ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
+      );
+      expect(creatorMap[1]).toEqual(
+        ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
+      );
     });
   });
 });

--- a/src/lib/helpers/config.helper.spec.ts
+++ b/src/lib/helpers/config.helper.spec.ts
@@ -1,4 +1,4 @@
-import { LSP3_UP_KEYS } from './config.helper';
+import { LSP3_UP_KEYS, LSP4_KEYS } from './config.helper';
 
 describe('Config Helpper', () => {
   it('should use the correct keys', () => {
@@ -7,6 +7,12 @@ describe('Config Helpper', () => {
     );
     expect(LSP3_UP_KEYS.UNIVERSAL_RECEIVER_DELEGATE_KEY).toEqual(
       '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47'
+    );
+    expect(LSP4_KEYS.LSP4_CREATORS_ARRAY).toEqual(
+      '0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7'
+    );
+    expect(LSP4_KEYS.LSP4_METADATA).toEqual(
+      '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e'
     );
   });
 });

--- a/src/lib/helpers/config.helper.ts
+++ b/src/lib/helpers/config.helper.ts
@@ -14,6 +14,8 @@ export const defaultUploadOptions: UploadOptions = {
   ipfsClientOptions: defaultIpfsClientOptions,
 };
 
+export const ERC725_ACCOUNT_INTERRFACE = '0x63cb749b';
+
 export const LSP3_UP_KEYS = {
   UNIVERSAL_RECEIVER_DELEGATE_KEY: keccak256(toUtf8Bytes('LSP1UniversalReceiverDelegate')),
   LSP3_PROFILE: keccak256(toUtf8Bytes('LSP3Profile')),
@@ -22,6 +24,7 @@ export const LSP3_UP_KEYS = {
 export const LSP4_KEYS = {
   LSP4_METADATA: keccak256(toUtf8Bytes('LSP4Metadata')),
   LSP4_CREATORS_ARRAY: keccak256(toUtf8Bytes('LSP4Creators[]')),
+  LSP4_CREATORS_MAP_PREFIX: '0x6de85eaf5d982b4e00000000',
 };
 
 export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';

--- a/src/lib/helpers/config.helper.ts
+++ b/src/lib/helpers/config.helper.ts
@@ -21,6 +21,7 @@ export const LSP3_UP_KEYS = {
 
 export const LSP4_KEYS = {
   LSP4_METADATA: keccak256(toUtf8Bytes('LSP4Metadata')),
+  LSP4_CREATORS_ARRAY: keccak256(toUtf8Bytes('LSP4Creators[]')),
 };
 
 export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -13,6 +13,7 @@ export interface DigitalAssetDeploymentOptions {
   name: string;
   symbol: string;
   digitalAssetMetadata?: LSP4MetadataBeforeUpload | string;
+  creators?: string[];
 }
 
 export interface LSP7DigitalAssetDeploymentOptions extends DigitalAssetDeploymentOptions {

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -22,7 +22,12 @@ import {
   LSP8MintableInit__factory,
 } from '../../';
 import { LSP4DigitalAssetMetadata } from '../classes/lsp4-digital-asset-metadata';
-import { GAS_BUFFER, GAS_PRICE, LSP4_KEYS } from '../helpers/config.helper';
+import {
+  ERC725_ACCOUNT_INTERRFACE,
+  GAS_BUFFER,
+  GAS_PRICE,
+  LSP4_KEYS,
+} from '../helpers/config.helper';
 import { deployContract, deployProxyContract, waitForReceipt } from '../helpers/deployment.helper';
 import { encodeLSP4Metadata } from '../helpers/erc725.helper';
 import { isMetadataEncoded } from '../helpers/uploader.helper';
@@ -455,6 +460,9 @@ async function setData(
   const creatorArrayIndexKeys: string[] = [];
   const creatorArrayIndexValues: string[] = [];
 
+  const creatorsMapKeys: string[] = [];
+  const creatorsMapValues: string[] = [];
+
   creators.forEach((creatorAddress, index) => {
     creatorArrayIndexKeys.push(
       LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
@@ -462,12 +470,19 @@ async function setData(
     );
 
     creatorArrayIndexValues.push(creatorAddress);
+
+    creatorsMapKeys.push(LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creatorAddress.slice(2));
+
+    creatorsMapValues.push(
+      ethers.utils.hexZeroPad(ethers.utils.hexlify([index]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
+    );
   });
 
-  const keysToSet = [LSP4_KEYS.LSP4_CREATORS_ARRAY, ...creatorArrayIndexKeys];
+  const keysToSet = [LSP4_KEYS.LSP4_CREATORS_ARRAY, ...creatorArrayIndexKeys, ...creatorsMapKeys];
   const valuesToSet = [
-    ethers.utils.defaultAbiCoder.encode(['uint256'], [creators.length]),
+    ethers.utils.hexZeroPad(ethers.utils.hexlify([creators.length]), 32),
     ...creatorArrayIndexValues,
+    ...creatorsMapValues,
   ];
 
   if (lsp4Metadata) {

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -1,6 +1,6 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import axios from 'axios';
-import { ContractFactory } from 'ethers';
+import { ContractFactory, ethers } from 'ethers';
 import {
   concat,
   EMPTY,
@@ -54,17 +54,15 @@ export function lsp7DigitalAssetDeployment$(
   signer: Signer,
   digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions,
   baseContractAddress$: Observable<string>,
-  lsp4Metadata$: Observable<string | null>,
   byteCode?: string
 ) {
-  return forkJoin([baseContractAddress$, lsp4Metadata$]).pipe(
-    switchMap(([baseContractAddress, lsp4Metadata]) => {
+  return baseContractAddress$.pipe(
+    switchMap((baseContractAddress) => {
       return lsp7DigitalAssetDeploymentWithBaseContractAddress$(
         signer,
         digitalAssetDeploymentOptions,
         baseContractAddress,
-        byteCode,
-        lsp4Metadata
+        byteCode
       );
     }),
     shareReplay()
@@ -75,17 +73,10 @@ export function lsp7DigitalAssetDeploymentWithBaseContractAddress$(
   signer: Signer,
   digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions,
   baseContractAddress?: string,
-  byteCode?: string,
-  lsp4Metadata?: string
+  byteCode?: string
 ) {
   const lsp7Deployment$ = from(
-    deployLSP7DigitalAsset(
-      signer,
-      digitalAssetDeploymentOptions,
-      baseContractAddress,
-      byteCode,
-      lsp4Metadata
-    )
+    deployLSP7DigitalAsset(signer, digitalAssetDeploymentOptions, baseContractAddress, byteCode)
   ).pipe(shareReplay());
 
   const lsp7DeploymentReceipt$ = waitForReceipt<DigitalAssetDeploymentEvent>(lsp7Deployment$).pipe(
@@ -96,8 +87,7 @@ export function lsp7DigitalAssetDeploymentWithBaseContractAddress$(
     ? initializeLSP7Proxy(
         signer,
         lsp7DeploymentReceipt$ as Observable<DeploymentEventProxyContract>,
-        digitalAssetDeploymentOptions,
-        lsp4Metadata
+        digitalAssetDeploymentOptions
       )
     : EMPTY;
 
@@ -112,12 +102,9 @@ async function deployLSP7DigitalAsset(
   signer: Signer,
   digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions,
   baseContractAddress?: string,
-  byteCode?: string,
-  lsp4Metadata?: string
+  byteCode?: string
 ) {
-  const controllerAddress = lsp4Metadata
-    ? await signer.getAddress()
-    : digitalAssetDeploymentOptions.controllerAddress;
+  const controllerAddress = await signer.getAddress();
 
   const deploymentFunction = async () => {
     if (baseContractAddress) {
@@ -154,8 +141,7 @@ async function deployLSP7DigitalAsset(
 function initializeLSP7Proxy(
   signer: Signer,
   digitalAssetDeploymentReceipt$: Observable<DeploymentEventProxyContract>,
-  digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions,
-  lsp4Metadata?: string
+  digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions
 ) {
   const { name, symbol, isNFT } = digitalAssetDeploymentOptions;
 
@@ -166,9 +152,7 @@ function initializeLSP7Proxy(
         result.receipt.contractAddress
       );
 
-      const controllerAddress = lsp4Metadata
-        ? await signer.getAddress()
-        : digitalAssetDeploymentOptions.controllerAddress;
+      const controllerAddress = await signer.getAddress();
 
       const gasEstimate = await contract.estimateGas[`initialize(string,string,address,bool)`](
         name,
@@ -211,17 +195,15 @@ export function lsp8IdentifiableDigitalAssetDeployment$(
   signer: Signer,
   digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   baseContractAddress$: Observable<string>,
-  lsp4MetadataUpload$: Observable<string | null>,
   byteCode?: string
 ) {
-  return forkJoin([baseContractAddress$, lsp4MetadataUpload$]).pipe(
-    switchMap(([baseContractAddress, lsp4Metadata]) => {
+  return baseContractAddress$.pipe(
+    switchMap((baseContractAddress) => {
       return lsp8IdentifiableDigitalAssetDeploymentWithBaseContractAddress$(
         signer,
         digitalAssetDeploymentOptions,
         baseContractAddress,
-        byteCode,
-        lsp4Metadata
+        byteCode
       );
     }),
     shareReplay()
@@ -232,16 +214,14 @@ export function lsp8IdentifiableDigitalAssetDeploymentWithBaseContractAddress$(
   signer: Signer,
   digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   baseContractAddress: string,
-  byteCode?: string,
-  lsp4Metadata?: string
+  byteCode?: string
 ) {
   const lsp8Deployment$ = from(
     deployLSP8IdentifiableDigitalAsset(
       signer,
       digitalAssetDeploymentOptions,
       baseContractAddress,
-      byteCode,
-      lsp4Metadata
+      byteCode
     )
   ).pipe(shareReplay());
 
@@ -251,8 +231,7 @@ export function lsp8IdentifiableDigitalAssetDeploymentWithBaseContractAddress$(
     ? initializeLSP8Proxy(
         signer,
         lsp8DeploymentReceipt$ as Observable<DeploymentEventProxyContract>,
-        digitalAssetDeploymentOptions,
-        lsp4Metadata
+        digitalAssetDeploymentOptions
       )
     : EMPTY;
 
@@ -267,12 +246,9 @@ async function deployLSP8IdentifiableDigitalAsset(
   signer: Signer,
   digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   baseContractAddress: string,
-  byteCode?: string,
-  lsp4Metadata?: string
+  byteCode?: string
 ) {
-  const controllerAddress = lsp4Metadata
-    ? await signer.getAddress()
-    : digitalAssetDeploymentOptions.controllerAddress;
+  const controllerAddress = await signer.getAddress();
 
   const deploymentFunction = async () => {
     if (baseContractAddress) {
@@ -311,8 +287,7 @@ async function deployLSP8IdentifiableDigitalAsset(
 function initializeLSP8Proxy(
   signer: Signer,
   digitalAssetDeploymentReceipt$: Observable<DeploymentEventProxyContract>,
-  digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
-  lsp4Metadata?: string
+  digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions
 ) {
   const { name, symbol } = digitalAssetDeploymentOptions;
 
@@ -323,9 +298,7 @@ function initializeLSP8Proxy(
         result.receipt.contractAddress
       );
 
-      const controllerAddress = lsp4Metadata
-        ? await signer.getAddress()
-        : digitalAssetDeploymentOptions.controllerAddress;
+      const controllerAddress = await signer.getAddress();
 
       const gasEstimate = await contract.estimateGas[`initialize(string,string,address)`](
         name,
@@ -432,16 +405,15 @@ export function setMetadataAndTransferOwnership$(
   digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   contractName: string
 ) {
-  return lsp4Metadata$.pipe(
-    switchMap((lsp4Metadata) => {
-      return lsp4Metadata
-        ? concat(
-            setLSP4Metadata$(signer, digitalAsset$, lsp4Metadata$, contractName),
-            transferOwnership$(signer, digitalAsset$, digitalAssetDeploymentOptions, contractName)
-          )
-        : EMPTY;
-    }),
-    shareReplay()
+  return concat(
+    setLSP4Metadata$(
+      signer,
+      digitalAsset$,
+      lsp4Metadata$,
+      contractName,
+      digitalAssetDeploymentOptions
+    ),
+    transferOwnership$(signer, digitalAsset$, digitalAssetDeploymentOptions, contractName)
   );
 }
 
@@ -449,18 +421,18 @@ export function setLSP4Metadata$(
   signer: Signer,
   digitalAsset$: Observable<DigitalAssetDeploymentEvent>,
   lsp4Metadata$: Observable<string | null>,
-  contractName: string
+  contractName: string,
+  digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions
 ): Observable<DeploymentEventTransaction> {
   const setDataTransaction$ = forkJoin([digitalAsset$, lsp4Metadata$]).pipe(
     switchMap(([{ receipt: digitalAssetReceipt }, lsp4Metadata]) => {
-      return lsp4Metadata
-        ? setData(
-            signer,
-            digitalAssetReceipt.contractAddress || digitalAssetReceipt.to,
-            lsp4Metadata,
-            contractName
-          )
-        : EMPTY;
+      return setData(
+        signer,
+        digitalAssetReceipt.contractAddress || digitalAssetReceipt.to,
+        lsp4Metadata,
+        digitalAssetDeploymentOptions,
+        contractName
+      );
     }),
     shareReplay()
   );
@@ -473,20 +445,39 @@ async function setData(
   signer: Signer,
   digitalAssetAddress: string,
   lsp4Metadata: string,
+  digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   contractName: string
 ): Promise<DeploymentEventTransaction> {
   const digitalAsset = new LSP7Mintable__factory(signer).attach(digitalAssetAddress);
 
-  const keysToSet = [LSP4_KEYS.LSP4_METADATA];
-  const valuesToSet = [lsp4Metadata];
+  const creators = digitalAssetDeploymentOptions?.creators ?? [];
 
-  const gasEstimate = await digitalAsset.estimateGas.setData(
-    [LSP4_KEYS.LSP4_METADATA],
-    [lsp4Metadata],
-    {
-      gasPrice: GAS_PRICE,
-    }
-  );
+  const creatorArrayIndexKeys: string[] = [];
+  const creatorArrayIndexValues: string[] = [];
+
+  creators.forEach((creatorAddress, index) => {
+    creatorArrayIndexKeys.push(
+      LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
+        ethers.utils.hexZeroPad(ethers.utils.hexlify([index]), 16).substring(2)
+    );
+
+    creatorArrayIndexValues.push(creatorAddress);
+  });
+
+  const keysToSet = [LSP4_KEYS.LSP4_CREATORS_ARRAY, ...creatorArrayIndexKeys];
+  const valuesToSet = [
+    ethers.utils.defaultAbiCoder.encode(['uint256'], [creators.length]),
+    ...creatorArrayIndexValues,
+  ];
+
+  if (lsp4Metadata) {
+    keysToSet.push(LSP4_KEYS.LSP4_METADATA);
+    valuesToSet.push(lsp4Metadata);
+  }
+
+  const gasEstimate = await digitalAsset.estimateGas.setData(keysToSet, valuesToSet, {
+    gasPrice: GAS_PRICE,
+  });
 
   const transaction = await digitalAsset.setData(keysToSet, valuesToSet, {
     gasLimit: gasEstimate.add(GAS_BUFFER),

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -245,8 +245,6 @@ export async function setData(
   controllerAddresses: (string | ControllerOptions)[],
   lsp3Profile?: LSP3ProfileDataForEncoding | string
 ): Promise<DeploymentEventTransaction> {
-  const abiCoder = ethers.utils.defaultAbiCoder;
-
   // TODO: move this to profile upload logic
   let encodedLSP3Profile;
   if (lsp3Profile && typeof lsp3Profile !== 'string') {
@@ -311,7 +309,7 @@ export async function setData(
     universalReceiverDelegateAddress,
     ...signersPermissions,
     SET_DATA_PERMISSION,
-    abiCoder.encode(['uint256'], [signersPermissions.length]),
+    ethers.utils.defaultAbiCoder.encode(['uint256'], [signersPermissions.length]),
     ...signersAddresses,
     universalReceiverDelegateAddress,
   ];


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Feature

Adds LSP4Creators key for creators[] value passed in digital asset options
