### PR TITLE
chore: update contract versions to 0.5.0

### DIFF
--- a/src/lib/classes/proxy-deployer.ts
+++ b/src/lib/classes/proxy-deployer.ts
@@ -12,6 +12,7 @@ import {
   UniversalProfileInit,
   UniversalProfileInit__factory,
 } from '../../';
+import { NULL_ADDRESS } from '../helpers/config.helper';
 import { getProxyByteCode } from '../helpers/deployment.helper';
 
 export class ProxyDeployer {
@@ -43,11 +44,15 @@ export class ProxyDeployer {
   }
 
   async deployLSP7BaseContract() {
-    return await new LSP7MintableInit__factory(this.signer).deploy();
+    const lsp7Init = await new LSP7MintableInit__factory(this.signer).deploy();
+    await lsp7Init['initialize(string,string,address,bool)']('', '', NULL_ADDRESS, false);
+    return lsp7Init;
   }
 
   async deployLSP8BaseContract() {
-    return await new LSP8MintableInit__factory(this.signer).deploy();
+    const lsp8Init = await new LSP8MintableInit__factory(this.signer).deploy();
+    await lsp8Init['initialize(string,string,address)']('', '', NULL_ADDRESS);
+    return lsp8Init;
   }
 
   async deployProxyContract<T extends Contract>(contract: T) {

--- a/src/lib/helpers/config.helper.ts
+++ b/src/lib/helpers/config.helper.ts
@@ -48,7 +48,7 @@ export const DEFAULT_PERMISSIONS = {
   SIGN: true,
 };
 
-export const DEFAULT_CONTRACT_VERSION = '0.0.1';
+export const DEFAULT_CONTRACT_VERSION = '0.5.0';
 
 export const GAS_PRICE = 10_000_000_000;
 export const GAS_BUFFER = 100_000;

--- a/src/versions.json
+++ b/src/versions.json
@@ -5,23 +5,33 @@
     "networkId": 22,
     "contracts": {
       "ERC725Account": {
-        "versions": { "0.0.1": "0xe6009BCbC6cb1046E72db3b50Ff0b9F3C94Db2fB" },
+        "versions": {
+          "0.5.0": "0x5EB0Aaac7C7C63F8cB06dbc7F48f9D5E61158E6a"
+        },
         "baseContract": true
       },
       "KeyManager": {
-        "versions": { "0.0.1": "0x36C80542f7ed462cc3fdB2b7AC1a83A80C5dD0f6" },
+        "versions": {
+          "0.5.0": "0x97939C42d23e70b245ce18B20D03191AC451701a"
+        },
         "baseContract": true
       },
       "UniversalReceiverDelegate": {
-        "versions": { "0.0.1": "0xEE495c349eB1ae864bb0e899A71aBD0b660eE4f0" },
+        "versions": {
+          "0.5.0": "0xE2D6038acD92200790Df695Ebd13856CdF2a6942"
+        },
         "baseContract": false
       },
       "LSP7Mintable": {
-        "versions": { "0.0.1": "0x78CFf775e3084E9B064FB59FC25b6143f1ddB831" },
+        "versions": {
+          "0.5.0": "0x99AA90a7C44e5Ce4C1960dc72Dda5C45De37EA4B"
+        },
         "baseContract": true
       },
       "LSP8Mintable": {
-        "versions": { "0.0.1": "0x61ADBa4744d78280d9A0D5012FdA25398068EAFb" },
+        "versions": {
+          "0.5.0": "0x9486f66B2CD54a04B75F8E3b1088C46B02F05F26"
+        },
         "baseContract": true
       }
     }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Imrpovemenet

### What is the current behaviour (you can also link to an open issue here)?
Uses wrong version names

### What is the new behaviour (if this is a feature change)?
Add version 0.5.0  as default contract versions
