### PR TITLE
ci: remove autogenerated docs from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,6 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Update Docs
-        run: npm run doc:html
-
-      - name: Publish Docs
-        run: npm run doc:publish
-
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
CI

Removes autogenerated docs from CI, this is legacy behaviour

