### PR TITLE
chore: improve return typing for deploy methods

### DIFF
--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -4,7 +4,6 @@ import UniversalProfileContract from '@lukso/lsp-smart-contracts/artifacts/Unive
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { providers } from 'ethers';
 import { ethers } from 'hardhat';
-import { Observable } from 'rxjs';
 
 import {
   LSP1UniversalReceiverDelegateUP__factory,
@@ -51,10 +50,10 @@ describe('LSP3UniversalProfile', () => {
     beforeAll(async () => {
       signer = signers[0];
 
-      const { ERC725Account, KeyManager } = (await lspFactory.LSP3UniversalProfile.deploy({
+      const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy({
         controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
         lsp3Profile: lsp3ProfileJson,
-      })) as DeployedContracts;
+      });
 
       universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
       keyManager = KeyManager;
@@ -79,7 +78,7 @@ describe('LSP3UniversalProfile', () => {
     beforeAll(async () => {
       signer = signers[0];
 
-      const { ERC725Account, KeyManager } = (await lspFactory.LSP3UniversalProfile.deploy(
+      const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy(
         {
           controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
           lsp3Profile: lsp3ProfileJson,
@@ -89,7 +88,7 @@ describe('LSP3UniversalProfile', () => {
             ipfsClientOptions: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
           },
         }
-      )) as DeployedContracts;
+      );
 
       universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
       keyManager = KeyManager;
@@ -114,9 +113,9 @@ describe('LSP3UniversalProfile', () => {
     beforeAll(async () => {
       uniqueController = signers[0];
 
-      const { ERC725Account } = (await lspFactory.LSP3UniversalProfile.deploy({
+      const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
         controllerAddresses: [uniqueController.address],
-      })) as DeployedContracts;
+      });
 
       universalProfile = UniversalProfile__factory.connect(ERC725Account.address, uniqueController);
     });
@@ -151,9 +150,9 @@ describe('LSP3UniversalProfile', () => {
       firstControllerAddress = signers[0].address;
       secondControllerAddress = signers[1].address;
 
-      const { ERC725Account, KeyManager } = (await lspFactory.LSP3UniversalProfile.deploy({
+      const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy({
         controllerAddresses: [firstControllerAddress, secondControllerAddress],
-      })) as DeployedContracts;
+      });
 
       universalProfile = new ethers.Contract(
         ERC725Account.address,
@@ -221,7 +220,7 @@ describe('LSP3UniversalProfile', () => {
         {
           deployReactive: true,
         }
-      ) as Observable<DeploymentEvent>;
+      );
 
       let erc725Address: string;
       let keyManagerAddress: string;

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -36,7 +36,7 @@ import {
 } from './../services/lsp3-account.service';
 import { universalReceiverDelegateDeployment$ } from './../services/universal-receiver.service';
 
-type ObservableOrPromise<
+type UniversalProfileObservableOrPromise<
   T extends ContractDeploymentOptionsReactive | ContractDeploymentOptionsNonReactive
 > = T extends ContractDeploymentOptionsReactive
   ? Observable<DeploymentEventContract | DeploymentEventTransaction>
@@ -83,7 +83,7 @@ export class LSP3UniversalProfile {
   >(
     profileDeploymentOptions: ProfileDeploymentOptions,
     contractDeploymentOptions?: T
-  ): ObservableOrPromise<T> {
+  ): UniversalProfileObservableOrPromise<T> {
     // -1 > Run IPFS upload process in parallel with contract deployment
     const lsp3Profile$ = lsp3ProfileUpload$(
       profileDeploymentOptions.lsp3Profile,
@@ -190,9 +190,10 @@ export class LSP3UniversalProfile {
       transferOwnership$,
     ]).pipe(concatAll());
 
-    if (contractDeploymentOptions?.deployReactive) return deployment$ as ObservableOrPromise<T>;
+    if (contractDeploymentOptions?.deployReactive)
+      return deployment$ as UniversalProfileObservableOrPromise<T>;
 
-    return waitForContractDeployment$(deployment$) as ObservableOrPromise<T>;
+    return waitForContractDeployment$(deployment$) as UniversalProfileObservableOrPromise<T>;
   }
 
   /**

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -27,7 +27,7 @@ import {
   setMetadataAndTransferOwnership$,
 } from '../services/digital-asset.service';
 
-type ObservableOrPromise<
+type LSP7ObservableOrPromise<
   T extends ContractDeploymentOptionsReactive | ContractDeploymentOptionsNonReactive
 > = T extends ContractDeploymentOptionsReactive
   ? Observable<DeploymentEventContract | DeploymentEventTransaction>
@@ -75,7 +75,7 @@ export class LSP7DigitalAsset {
   >(
     digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions,
     contractDeploymentOptions: T = undefined
-  ): ObservableOrPromise<T> {
+  ): LSP7ObservableOrPromise<T> {
     const lsp4Metadata$ = lsp4MetadataUpload$(
       digitalAssetDeploymentOptions.digitalAssetMetadata,
       contractDeploymentOptions?.uploadOptions ?? this.options.uploadOptions
@@ -131,10 +131,8 @@ export class LSP7DigitalAsset {
       setLSP4AndTransferOwnership$,
     ]).pipe(concatAll());
 
-    if (contractDeploymentOptions?.deployReactive) return deployment$ as ObservableOrPromise<T>;
+    if (contractDeploymentOptions?.deployReactive) return deployment$ as LSP7ObservableOrPromise<T>;
 
-    return waitForContractDeployment$(
-      deployment$
-    ) as Promise<DeployedLSP7DigitalAsset> as ObservableOrPromise<T>;
+    return waitForContractDeployment$(deployment$) as LSP7ObservableOrPromise<T>;
   }
 }

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { providers } from 'ethers';
 import { ethers } from 'hardhat';
-import { Observable } from 'rxjs';
 
 import {
   DeploymentEvent,
@@ -9,7 +8,6 @@ import {
   LSP7Mintable__factory,
   LSPFactory,
 } from '../../../build/main/src/index';
-import { DeployedLSP7DigitalAsset } from '../../../build/main/src/lib/interfaces/digital-asset-deployment';
 import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 
 import { lsp4DigitalAsset } from './../../../test/lsp4-digital-asset.mock';
@@ -34,12 +32,12 @@ describe('LSP7DigitalAsset', () => {
   it('should deploy LSP7 Digital asset with no passed deployment options', async () => {
     const myLSPFactory = new LSPFactory(provider, signer);
 
-    const lsp7DigitalAsset = (await myLSPFactory.LSP7DigitalAsset.deploy({
+    const lsp7DigitalAsset = await myLSPFactory.LSP7DigitalAsset.deploy({
       controllerAddress: signer.address,
       isNFT: false,
       name: 'TOKEN',
       symbol: 'TKN',
-    })) as DeployedLSP7DigitalAsset;
+    });
 
     expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp7DigitalAsset).length).toEqual(2);
@@ -56,7 +54,7 @@ describe('LSP7DigitalAsset', () => {
   it('should deploy LSP7 Digital asset from specified base contract', async () => {
     const myLSPFactory = new LSPFactory(provider, signer);
 
-    const lsp7DigitalAsset = (await myLSPFactory.LSP7DigitalAsset.deploy(
+    const lsp7DigitalAsset = await myLSPFactory.LSP7DigitalAsset.deploy(
       {
         controllerAddress: signer.address,
         isNFT: false,
@@ -66,7 +64,7 @@ describe('LSP7DigitalAsset', () => {
       {
         libAddress: baseContract.address,
       }
-    )) as DeployedLSP7DigitalAsset;
+    );
 
     expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp7DigitalAsset).length).toEqual(1);
@@ -83,7 +81,7 @@ describe('LSP7DigitalAsset', () => {
   it('should deploy LSP7 Digital asset without a base contract', async () => {
     const myLSPFactory = new LSPFactory(provider, signer);
 
-    const lsp7DigitalAsset = (await myLSPFactory.LSP7DigitalAsset.deploy(
+    const lsp7DigitalAsset = await myLSPFactory.LSP7DigitalAsset.deploy(
       {
         controllerAddress: signer.address,
         isNFT: false,
@@ -93,7 +91,7 @@ describe('LSP7DigitalAsset', () => {
       {
         deployProxy: false,
       }
-    )) as DeployedLSP7DigitalAsset;
+    );
 
     expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp7DigitalAsset).length).toEqual(1);
@@ -121,7 +119,7 @@ describe('LSP7DigitalAsset', () => {
         deployReactive: true,
         deployProxy: true,
       }
-    ) as Observable<DeploymentEvent>;
+    );
 
     let lsp7Address: string;
 
@@ -154,7 +152,7 @@ describe('LSP7DigitalAsset', () => {
 
     const passedBytecode = LSP7Mintable__factory.bytecode;
 
-    const lsp7DigitalAsset = (await lspFactory.LSP7DigitalAsset.deploy(
+    const lsp7DigitalAsset = await lspFactory.LSP7DigitalAsset.deploy(
       {
         controllerAddress: signer.address,
         isNFT: false,
@@ -164,7 +162,7 @@ describe('LSP7DigitalAsset', () => {
       {
         byteCode: passedBytecode,
       }
-    )) as DeployedLSP7DigitalAsset;
+    );
 
     expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp7DigitalAsset).length).toEqual(1);
@@ -197,13 +195,13 @@ describe('LSP7DigitalAsset', () => {
 
     it('should deploy lsp7 with metadata', async () => {
       const lspFactory = new LSPFactory(provider, signer);
-      const lsp7DigitalAsset = (await lspFactory.LSP7DigitalAsset.deploy({
+      const lsp7DigitalAsset = await lspFactory.LSP7DigitalAsset.deploy({
         controllerAddress,
         isNFT: false,
         name,
         symbol,
         digitalAssetMetadata: lsp4DigitalAsset.LSP4Metadata,
-      })) as DeployedLSP7DigitalAsset;
+      });
 
       expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
       expect(Object.keys(lsp7DigitalAsset).length).toEqual(2);
@@ -246,13 +244,13 @@ describe('LSP7DigitalAsset', () => {
 
     it('should deploy with specified creators', async () => {
       const lspFactory = new LSPFactory(provider, signer);
-      const lsp7DigitalAsset = (await lspFactory.LSP7DigitalAsset.deploy({
+      const lsp7DigitalAsset = await lspFactory.LSP7DigitalAsset.deploy({
         controllerAddress,
         name,
         symbol,
         creators,
         isNFT,
-      })) as DeployedLSP7DigitalAsset;
+      });
 
       expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
       expect(Object.keys(lsp7DigitalAsset).length).toEqual(2);

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -27,7 +27,7 @@ import {
   setMetadataAndTransferOwnership$,
 } from '../services/digital-asset.service';
 
-type ObservableOrPromise<
+type LSP8ObservableOrPromise<
   T extends ContractDeploymentOptionsReactive | ContractDeploymentOptionsNonReactive
 > = T extends ContractDeploymentOptionsReactive
   ? Observable<DeploymentEventContract | DeploymentEventTransaction>
@@ -74,7 +74,7 @@ export class LSP8IdentifiableDigitalAsset {
   >(
     digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
     contractDeploymentOptions?: T
-  ): ObservableOrPromise<T> {
+  ): LSP8ObservableOrPromise<T> {
     const lsp4Metadata$ = lsp4MetadataUpload$(
       digitalAssetDeploymentOptions.digitalAssetMetadata,
       contractDeploymentOptions?.uploadOptions ?? this.options.uploadOptions
@@ -130,8 +130,8 @@ export class LSP8IdentifiableDigitalAsset {
       setLSP4AndTransferOwnership$,
     ]).pipe(concatAll());
 
-    if (contractDeploymentOptions?.deployReactive) return deployment$ as ObservableOrPromise<T>;
+    if (contractDeploymentOptions?.deployReactive) return deployment$ as LSP8ObservableOrPromise<T>;
 
-    return waitForContractDeployment$(deployment$) as ObservableOrPromise<T>;
+    return waitForContractDeployment$(deployment$) as LSP8ObservableOrPromise<T>;
   }
 }

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { providers } from 'ethers';
 import { ethers } from 'hardhat';
-import { Observable } from 'rxjs';
 
 import {
   DeploymentEvent,
@@ -9,7 +8,6 @@ import {
   LSP8Mintable__factory,
   LSPFactory,
 } from '../../../build/main/src/index';
-import { DeployedLSP8IdentifiableDigitalAsset } from '../../../build/main/src/lib/interfaces/digital-asset-deployment';
 import { lsp4DigitalAsset } from '../../../test/lsp4-digital-asset.mock';
 import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 
@@ -34,11 +32,11 @@ describe('LSP8IdentifiableDigitalAsset', () => {
   it('should deploy LSP8 Identifiable Digital asset with no passed deployment options', async () => {
     const myLSPFactory = new LSPFactory(provider, signer);
 
-    const lsp8IdentifiableDigitalAsset = (await myLSPFactory.LSP8IdentifiableDigitalAsset.deploy({
+    const lsp8IdentifiableDigitalAsset = await myLSPFactory.LSP8IdentifiableDigitalAsset.deploy({
       controllerAddress: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
       name: 'TOKEN',
       symbol: 'TKN',
-    })) as DeployedLSP8IdentifiableDigitalAsset;
+    });
 
     expect(lsp8IdentifiableDigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp8IdentifiableDigitalAsset).length).toEqual(2);
@@ -55,7 +53,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
   it('should deploy LSP8 Identifiable Digital asset from a specified base contract', async () => {
     const myLSPFactory = new LSPFactory(provider, signer);
 
-    const lsp8IdentifiableDigitalAsset = (await myLSPFactory.LSP8IdentifiableDigitalAsset.deploy(
+    const lsp8IdentifiableDigitalAsset = await myLSPFactory.LSP8IdentifiableDigitalAsset.deploy(
       {
         controllerAddress: signer.address,
         name: 'TOKEN',
@@ -64,7 +62,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
       {
         libAddress: baseContract.address,
       }
-    )) as DeployedLSP8IdentifiableDigitalAsset;
+    );
 
     expect(lsp8IdentifiableDigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp8IdentifiableDigitalAsset).length).toEqual(1);
@@ -91,7 +89,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
         libAddress: baseContract.address,
         deployReactive: true,
       }
-    ) as Observable<DeploymentEvent>;
+    );
 
     let lsp8Address: string;
 
@@ -121,7 +119,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
   it('should deploy LSP8 Identifiable Digital without a base contract', async () => {
     const myLSPFactory = new LSPFactory(provider, signer);
 
-    const lsp8IdentifiableDigitalAsset = (await myLSPFactory.LSP8IdentifiableDigitalAsset.deploy(
+    const lsp8IdentifiableDigitalAsset = await myLSPFactory.LSP8IdentifiableDigitalAsset.deploy(
       {
         controllerAddress: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
         name: 'TOKEN',
@@ -130,7 +128,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
       {
         deployProxy: false,
       }
-    )) as DeployedLSP8IdentifiableDigitalAsset;
+    );
 
     expect(lsp8IdentifiableDigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp8IdentifiableDigitalAsset).length).toEqual(1);
@@ -157,7 +155,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
         libAddress: baseContract.address,
         deployReactive: true,
       }
-    ) as Observable<DeploymentEvent>;
+    );
 
     let lsp8Address: string;
 
@@ -188,7 +186,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
 
     const passedBytecode = LSP8Mintable__factory.bytecode;
 
-    const lsp8IdentifiableDigitalAsset = (await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
+    const lsp8IdentifiableDigitalAsset = await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
       {
         controllerAddress: signer.address,
         name: 'TOKEN',
@@ -197,7 +195,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
       {
         byteCode: passedBytecode,
       }
-    )) as DeployedLSP8IdentifiableDigitalAsset;
+    );
 
     expect(lsp8IdentifiableDigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
     expect(Object.keys(lsp8IdentifiableDigitalAsset).length).toEqual(1);
@@ -237,12 +235,12 @@ describe('LSP8IdentifiableDigitalAsset', () => {
 
     it('should deploy lsp8 with metadata', async () => {
       const lspFactory = new LSPFactory(provider, signer);
-      const lsp8DigitalAsset = (await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
+      const lsp8DigitalAsset = await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
         controllerAddress,
         name,
         symbol,
         digitalAssetMetadata: lsp4DigitalAsset.LSP4Metadata,
-      })) as DeployedLSP8IdentifiableDigitalAsset;
+      });
 
       expect(lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
       expect(Object.keys(lsp8DigitalAsset).length).toEqual(2);
@@ -284,12 +282,12 @@ describe('LSP8IdentifiableDigitalAsset', () => {
 
     it('should deploy with specified creators', async () => {
       const lspFactory = new LSPFactory(provider, signer);
-      const lsp8DigitalAsset = (await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
+      const lsp8DigitalAsset = await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
         controllerAddress,
         name,
         symbol,
         creators,
-      })) as DeployedLSP8IdentifiableDigitalAsset;
+      });
 
       expect(lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
       expect(Object.keys(lsp8DigitalAsset).length).toEqual(2);

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -28,11 +28,24 @@ export interface DeployedLSP7DigitalAsset {
   LSP7DigitalAsset: DeployedContract;
 }
 
-export interface ContractDeploymentOptions {
+export interface ContractDeploymentOptionsReactive {
   version?: string;
   byteCode?: string;
   libAddress?: string;
-  deployReactive?: boolean;
+  deployReactive: true;
   deployProxy?: boolean;
   uploadOptions?: UploadOptions;
 }
+
+export interface ContractDeploymentOptionsNonReactive {
+  version?: string;
+  byteCode?: string;
+  libAddress?: string;
+  deployReactive?: false;
+  deployProxy?: boolean;
+  uploadOptions?: UploadOptions;
+}
+
+export type ContractDeploymentOptions =
+  | ContractDeploymentOptionsReactive
+  | ContractDeploymentOptionsNonReactive;

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -28,22 +28,19 @@ export interface DeployedLSP7DigitalAsset {
   LSP7DigitalAsset: DeployedContract;
 }
 
-export interface ContractDeploymentOptionsReactive {
+interface ContractDeploymentOptionsBase {
   version?: string;
   byteCode?: string;
   libAddress?: string;
-  deployReactive: true;
   deployProxy?: boolean;
   uploadOptions?: UploadOptions;
 }
+export interface ContractDeploymentOptionsReactive extends ContractDeploymentOptionsBase {
+  deployReactive: true;
+}
 
-export interface ContractDeploymentOptionsNonReactive {
-  version?: string;
-  byteCode?: string;
-  libAddress?: string;
+export interface ContractDeploymentOptionsNonReactive extends ContractDeploymentOptionsBase {
   deployReactive?: false;
-  deployProxy?: boolean;
-  uploadOptions?: UploadOptions;
 }
 
 export type ContractDeploymentOptions =

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -48,22 +48,20 @@ interface ContractOptions {
   libAddress?: string;
 }
 
-export interface ContractDeploymentOptionsReactive {
+interface ContractDeploymentOptionsBase {
   version?: string;
-  deployReactive: true;
   uploadOptions?: UploadOptions;
   ERC725Account?: ContractOptions;
   KeyManager?: ContractOptions;
   UniversalReceiverDelegate?: ContractOptions;
 }
 
-export interface ContractDeploymentOptionsNonReactive {
-  version?: string;
+export interface ContractDeploymentOptionsReactive extends ContractDeploymentOptionsBase {
+  deployReactive: true;
+}
+
+export interface ContractDeploymentOptionsNonReactive extends ContractDeploymentOptionsBase {
   deployReactive?: false;
-  uploadOptions?: UploadOptions;
-  ERC725Account?: ContractOptions;
-  KeyManager?: ContractOptions;
-  UniversalReceiverDelegate?: ContractOptions;
 }
 
 export type ContractDeploymentOptions =

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -47,11 +47,25 @@ interface ContractOptions {
   deployProxy?: boolean;
   libAddress?: string;
 }
-export interface ContractDeploymentOptions {
+
+export interface ContractDeploymentOptionsReactive {
   version?: string;
-  deployReactive?: boolean;
+  deployReactive: true;
   uploadOptions?: UploadOptions;
   ERC725Account?: ContractOptions;
   KeyManager?: ContractOptions;
   UniversalReceiverDelegate?: ContractOptions;
 }
+
+export interface ContractDeploymentOptionsNonReactive {
+  version?: string;
+  deployReactive?: false;
+  uploadOptions?: UploadOptions;
+  ERC725Account?: ContractOptions;
+  KeyManager?: ContractOptions;
+  UniversalReceiverDelegate?: ContractOptions;
+}
+
+export type ContractDeploymentOptions =
+  | ContractDeploymentOptionsReactive
+  | ContractDeploymentOptionsNonReactive;


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
improvement

### What is the current behaviour (you can also link to an open issue here)?
Return type of `deploy` methods are not inferred based on the `deployReactive` parameter. This means developers need to cast types to avoid errors.

### What is the new behaviour (if this is a feature change)?
Return type is conditionally determined based on the `deployReactive` parameter. if `deployReactive: true` return type is Observable, if `deployReactive: false` or omitted return type is Promise
