### PR TITLE
feat: allow passing window.ethereum object during instantiation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,15 +30,12 @@ const lspFactory = new LSPFactory(provider, {
 
 ## Using LSPFactory in a Dapp
 
-If being used in the browser in a Dapp, pass the ethereum window object as the provider paramter to intergrate with a browser extension like MetaMask. This will then prompt users to sign the transactions the LSPFactory sends. In this case the `Signer` field may be left blank.
-
-Promt the user to connect to the Dapp using the ethereum `eth_requestAccounts` method. Then pass the ethereum window object as the provider when instantiating LSPFactory.
-
-The user will then be prompted to confirm transactions sent by LSPFactory inside their browser extension.
+If being used in the browser in a Dapp, pass the `ethereum` object as the provider parameter to connect to a browser extension like the UniversalProfile Browser extension or MetaMask. This will then prompt users to sign the transactions the LSPFactory deploys smart contracts.
 
 ```javascript
-await window.ethereum.request({ method: 'eth_requestAccounts' });
-const lspFactory = new LSPFactory(window.ethereum);
+await ethereum.request({ method: 'eth_requestAccounts', params: [] });
+
+const lspFactory = new LSPFactory(ethereum);
 ```
 
 ## Usage

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,13 +20,25 @@ npm install @lukso/lsp-factory.js
 ```javascript
 import { LSPFactory } from '@lukso/lsp-factory.js';
 
-
 const provider = 'https://rpc.l14.lukso.network'; // RPC provider url
 
 const lspFactory = new LSPFactory(provider, {
   deployKey: '0x...', // Private key of the account which will deploy any smart contract,
   chainId: 22, // Chain Id of the network you want to deploy to
 });
+```
+
+## Using LSPFactory in a Dapp
+
+If being used in the browser in a Dapp, pass the ethereum window object as the provider paramter to intergrate with a browser extension like MetaMask. This will then prompt users to sign the transactions the LSPFactory sends. In this case the `Signer` field may be left blank.
+
+Promt the user to connect to the Dapp using the ethereum `eth_requestAccounts` method. Then pass the ethereum window object as the provider when instantiating LSPFactory.
+
+The user will then be prompted to confirm transactions sent by LSPFactory inside their browser extension.
+
+```javascript
+await window.ethereum.request({ method: 'eth_requestAccounts' });
+const lspFactory = new LSPFactory(window.ethereum);
 ```
 
 ## Usage

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -31,6 +31,7 @@ import { keyManagerDeployment$ } from '../services/key-manager.service';
 import {
   accountDeployment$,
   getTransferOwnershipTransaction$,
+  isSignerUniversalProfile$,
   lsp3ProfileUpload$,
   setDataTransaction$,
 } from './../services/lsp3-account.service';
@@ -143,11 +144,14 @@ export class LSP3UniversalProfile {
       contractDeploymentOptions?.ERC725Account?.byteCode
     );
 
+    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
+
     // 2 > deploys KeyManager
     const keyManager$ = keyManagerDeployment$(
       this.signer,
       account$,
       baseContractAddresses$,
+      signerIsUniversalProfile$,
       contractDeploymentOptions?.KeyManager?.byteCode
     );
 
@@ -170,11 +174,17 @@ export class LSP3UniversalProfile {
       universalReceiver$,
       profileDeploymentOptions.controllerAddresses,
       lsp3Profile$,
+      signerIsUniversalProfile$,
       defaultUniversalReceiverAddress
     );
 
     // 5 > transfersOwnership to KeyManager
-    const transferOwnership$ = getTransferOwnershipTransaction$(this.signer, account$, keyManager$);
+    const transferOwnership$ = getTransferOwnershipTransaction$(
+      this.signer,
+      account$,
+      keyManager$,
+      signerIsUniversalProfile$
+    );
 
     const deployment$ = concat([
       baseContractDeployment$,

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -136,14 +136,9 @@ export class LSP3UniversalProfile {
       deployUniversalReceiverProxy
     );
 
-    const controllerAddresses = profileDeploymentOptions.controllerAddresses.map((controller) => {
-      return typeof controller === 'string' ? controller : controller.address;
-    });
-
     // 1 > deploys ERC725Account
     const account$ = accountDeployment$(
       this.signer,
-      controllerAddresses,
       baseContractAddresses$,
       contractDeploymentOptions?.ERC725Account?.byteCode
     );

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -26,6 +26,7 @@ import {
   lsp7DigitalAssetDeployment$,
   setMetadataAndTransferOwnership$,
 } from '../services/digital-asset.service';
+import { isSignerUniversalProfile$ } from '../services/lsp3-account.service';
 
 type LSP7ObservableOrPromise<
   T extends ContractDeploymentOptionsReactive | ContractDeploymentOptionsNonReactive
@@ -117,12 +118,15 @@ export class LSP7DigitalAsset {
       contractDeploymentOptions?.byteCode
     );
 
+    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
+
     const setLSP4AndTransferOwnership$ = setMetadataAndTransferOwnership$(
       this.signer,
       digitalAsset$,
       lsp4Metadata$,
       digitalAssetDeploymentOptions,
-      ContractNames.LSP7_DIGITAL_ASSET
+      ContractNames.LSP7_DIGITAL_ASSET,
+      signerIsUniversalProfile$
     );
 
     const deployment$ = concat([

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -26,6 +26,7 @@ import {
   lsp8IdentifiableDigitalAssetDeployment$,
   setMetadataAndTransferOwnership$,
 } from '../services/digital-asset.service';
+import { isSignerUniversalProfile$ } from '../services/lsp3-account.service';
 
 type LSP8ObservableOrPromise<
   T extends ContractDeploymentOptionsReactive | ContractDeploymentOptionsNonReactive
@@ -116,12 +117,15 @@ export class LSP8IdentifiableDigitalAsset {
       contractDeploymentOptions?.byteCode
     );
 
+    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
+
     const setLSP4AndTransferOwnership$ = setMetadataAndTransferOwnership$(
       this.signer,
       digitalAsset$,
       lsp4Metadata$,
       digitalAssetDeploymentOptions,
-      ContractNames.LSP8_DIGITAL_ASSET
+      ContractNames.LSP8_DIGITAL_ASSET,
+      signerIsUniversalProfile$
     );
 
     const deployment$ = concat([

--- a/src/lib/interfaces/deployment-events.ts
+++ b/src/lib/interfaces/deployment-events.ts
@@ -59,3 +59,19 @@ export type DeploymentEvent =
  * @internal
  */
 export type DeploymentEvent$ = Observable<DeploymentEvent>;
+
+export type EthersExternalProvider = {
+  isMetaMask?: boolean;
+  isStatus?: boolean;
+  host?: string;
+  path?: string;
+  sendAsync?: (
+    request: { method: string; params?: Array<any> },
+    callback: (error: any, response: any) => void
+  ) => void;
+  send?: (
+    request: { method: string; params?: Array<any> },
+    callback: (error: any, response: any) => void
+  ) => void;
+  request?: (request: { method: string; params?: Array<any> }) => Promise<any>;
+};

--- a/src/lib/lsp-factory.ts
+++ b/src/lib/lsp-factory.ts
@@ -40,7 +40,7 @@ export class LSPFactory {
 
     if (typeof rpcUrlOrProvider === 'string') {
       provider = new ethers.providers.JsonRpcProvider(rpcUrlOrProvider);
-    } else if ('isMetaMask' in rpcUrlOrProvider) {
+    } else if ('chainId' in rpcUrlOrProvider) {
       provider = new ethers.providers.Web3Provider(rpcUrlOrProvider);
     } else if (typeof rpcUrlOrProvider !== 'string') {
       provider = rpcUrlOrProvider as providers.Web3Provider | providers.JsonRpcProvider;

--- a/src/lib/lsp-factory.ts
+++ b/src/lib/lsp-factory.ts
@@ -5,7 +5,7 @@ import { LSP4DigitalAssetMetadata } from './classes/lsp4-digital-asset-metadata'
 import { LSP7DigitalAsset } from './classes/lsp7-digital-asset';
 import { LSP8IdentifiableDigitalAsset } from './classes/lsp8-identifiable-digital-asset';
 import { ProxyDeployer } from './classes/proxy-deployer';
-import { LSPFactoryOptions } from './interfaces';
+import { EthersExternalProvider, LSPFactoryOptions } from './interfaces';
 import { SignerOptions } from './interfaces/lsp-factory-options';
 
 /**
@@ -21,32 +21,37 @@ export class LSPFactory {
   /**
    * TBD
    *
-   * @param {string | providers.Web3Provider | providers.JsonRpcProvider} rpcUrlOrProvider
+   * @param {string | providers.Web3Provider | providers.JsonRpcProvider | EthersExternalProvider } rpcUrlOrProvider
    * @param {string | Signer | SignerOptions} privateKeyOrSigner
    * @param {number} [chainId=22] Lukso Testnet - 22 (0x16)
    */
   constructor(
-    rpcUrlOrProvider: string | providers.Web3Provider | providers.JsonRpcProvider,
-    privateKeyOrSigner: string | Signer | SignerOptions
+    rpcUrlOrProvider:
+      | string
+      | providers.Web3Provider
+      | providers.JsonRpcProvider
+      | EthersExternalProvider,
+    privateKeyOrSigner?: string | Signer | SignerOptions
   ) {
     let signer: Signer;
     let provider: providers.Web3Provider | providers.JsonRpcProvider;
     let chainId = 22;
     let uploadOptions;
 
-    if (
-      rpcUrlOrProvider instanceof providers.Web3Provider ||
-      rpcUrlOrProvider instanceof providers.JsonRpcProvider
-    ) {
-      provider = rpcUrlOrProvider;
-    } else {
+    if (typeof rpcUrlOrProvider === 'string') {
       provider = new ethers.providers.JsonRpcProvider(rpcUrlOrProvider);
+    } else if ('isMetaMask' in rpcUrlOrProvider) {
+      provider = new ethers.providers.Web3Provider(rpcUrlOrProvider);
+    } else if (typeof rpcUrlOrProvider !== 'string') {
+      provider = rpcUrlOrProvider as providers.Web3Provider | providers.JsonRpcProvider;
     }
 
     if (privateKeyOrSigner instanceof Signer) {
       signer = privateKeyOrSigner;
     } else if (typeof privateKeyOrSigner === 'string') {
       signer = new ethers.Wallet(privateKeyOrSigner, provider);
+    } else if (!privateKeyOrSigner) {
+      signer = provider.getSigner();
     } else {
       signer = new ethers.Wallet(privateKeyOrSigner.deployKey, provider);
       chainId = privateKeyOrSigner.chainId;

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -433,7 +433,7 @@ export function setLSP4Metadata$(
     switchMap(([{ receipt: digitalAssetReceipt }, lsp4Metadata]) => {
       return setData(
         signer,
-        digitalAssetReceipt.contractAddress || digitalAssetReceipt.to,
+        digitalAssetReceipt.contractAddress || digitalAssetReceipt.logs[0].address, // Check these values when deploying with UP
         lsp4Metadata,
         digitalAssetDeploymentOptions,
         contractName
@@ -518,7 +518,8 @@ export function transferOwnership$(
     switchMap(([{ receipt: digitalAssetDeploymentReceipt }]) => {
       return transferOwnership(
         signer,
-        digitalAssetDeploymentReceipt.contractAddress || digitalAssetDeploymentReceipt.to,
+        digitalAssetDeploymentReceipt.contractAddress ||
+          digitalAssetDeploymentReceipt.logs[0].address, // CHeck this when deploying with UP
         digitalAssetDeploymentOptions.controllerAddress,
         contractName
       );

--- a/src/lib/services/key-manager.service.ts
+++ b/src/lib/services/key-manager.service.ts
@@ -28,7 +28,8 @@ export function keyManagerDeployment$(
 ): Observable<KeyManagerDeploymentEvent> {
   return forkJoin([accountDeployment$, baseContractAddress$]).pipe(
     switchMap(([{ receipt: lsp3AccountReceipt }, baseContractAddress]) => {
-      const erc725AccountAddress = lsp3AccountReceipt.contractAddress || lsp3AccountReceipt.to;
+      const erc725AccountAddress =
+        lsp3AccountReceipt.contractAddress || lsp3AccountReceipt.logs[0].address;
       return keyManagerDeploymentForAccount$(
         signer,
         erc725AccountAddress,

--- a/src/lib/services/key-manager.service.ts
+++ b/src/lib/services/key-manager.service.ts
@@ -24,19 +24,24 @@ export function keyManagerDeployment$(
   signer: Signer,
   accountDeployment$: Observable<LSP3AccountDeploymentEvent>,
   baseContractAddress$: Observable<BaseContractAddresses>,
+  isSignerUniversalProfile$: Observable<boolean>,
   byteCode?: string
 ): Observable<KeyManagerDeploymentEvent> {
-  return forkJoin([accountDeployment$, baseContractAddress$]).pipe(
-    switchMap(([{ receipt: lsp3AccountReceipt }, baseContractAddress]) => {
-      const erc725AccountAddress =
-        lsp3AccountReceipt.contractAddress || lsp3AccountReceipt.logs[0].address;
-      return keyManagerDeploymentForAccount$(
-        signer,
-        erc725AccountAddress,
-        baseContractAddress.KeyManager,
-        byteCode
-      );
-    }),
+  return forkJoin([accountDeployment$, baseContractAddress$, isSignerUniversalProfile$]).pipe(
+    switchMap(
+      ([{ receipt: lsp3AccountReceipt }, baseContractAddress, isSignerUniversalProfile]) => {
+        const erc725AccountAddress = isSignerUniversalProfile
+          ? lsp3AccountReceipt.contractAddress || lsp3AccountReceipt.logs[0].address
+          : lsp3AccountReceipt.contractAddress || lsp3AccountReceipt.to;
+
+        return keyManagerDeploymentForAccount$(
+          signer,
+          erc725AccountAddress,
+          baseContractAddress.KeyManager,
+          byteCode
+        );
+      }
+    ),
     shareReplay()
   );
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Feature

### What is the new behaviour (if this is a feature change)?
Allows passing the window ethereum object as the provider on instantiation. This will then try and create a web3provider object to use as the signer for transactions to trigger browser extensions (e.g MetaMask) to confirm transactions
