### PR TITLE
feat: allow passing metadata formatted for erc725.js

### DIFF
--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -45,29 +45,50 @@ describe('LSP3UniversalProfile', () => {
   describe('Deploying with LSP3Profile Metadata', () => {
     let signer: SignerWithAddress;
     let universalProfile;
-    let keyManager;
+    const expectedLSP3Value =
+      '0x6f357c6a5af8bb903787236579aff8a6518c022fe655646fded5e1ea23ca7aedddb221a4697066733a2f2f516d624b76435645655069444b78756f7579747939624d73574241785a444772326a68786434704c474c78393544';
 
-    beforeAll(async () => {
-      signer = signers[0];
+    describe('passing metadata to be uploaded', () => {
+      it('should deploy and set LSP3Profile data', async () => {
+        signer = signers[0];
 
-      const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy({
-        controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-        lsp3Profile: lsp3ProfileJson,
+        const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
+          controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
+          lsp3Profile: lsp3ProfileJson.LSP3Profile,
+        });
+
+        universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
+
+        const data = await universalProfile.getData([
+          '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+        ]);
+
+        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+        expect(data[0]).toEqual(expectedLSP3Value);
       });
-
-      universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
-      keyManager = KeyManager;
     });
 
-    it('should deploy and set LSP3Profile data', async () => {
-      const ownerAddress = await universalProfile.owner();
-      expect(ownerAddress).toEqual(keyManager.address);
+    describe('passing metadata ready for encoding', () => {
+      it('should allow passing url and json', async () => {
+        signer = signers[0];
 
-      const data = await universalProfile.getData([
-        '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-      ]);
+        const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
+          controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
+          lsp3Profile: {
+            json: lsp3ProfileJson,
+            url: 'ipfs://QmbKvCVEePiDKxuouyty9bMsWBAxZDGr2jhxd4pLGLx95D',
+          },
+        });
 
-      expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+        universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
+
+        const data = await universalProfile.getData([
+          '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+        ]);
+
+        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+        expect(data[0]).toEqual(expectedLSP3Value);
+      });
     });
   });
   describe('Deploying with LSP3Profile Metadata with specified IPFS client options', () => {
@@ -81,7 +102,7 @@ describe('LSP3UniversalProfile', () => {
       const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy(
         {
           controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-          lsp3Profile: lsp3ProfileJson,
+          lsp3Profile: lsp3ProfileJson.LSP3Profile,
         },
         {
           uploadOptions: {
@@ -215,7 +236,7 @@ describe('LSP3UniversalProfile', () => {
       const deployments$ = lspFactory.LSP3UniversalProfile.deploy(
         {
           controllerAddresses: [signers[0].address],
-          lsp3Profile: lsp3ProfileJson,
+          lsp3Profile: lsp3ProfileJson.LSP3Profile,
         },
         {
           deployReactive: true,

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -48,46 +48,30 @@ describe('LSP3UniversalProfile', () => {
     const expectedLSP3Value =
       '0x6f357c6a5af8bb903787236579aff8a6518c022fe655646fded5e1ea23ca7aedddb221a4697066733a2f2f516d624b76435645655069444b78756f7579747939624d73574241785a444772326a68786434704c474c78393544';
 
-    describe('passing metadata to be uploaded', () => {
-      it('should deploy and set LSP3Profile data', async () => {
-        signer = signers[0];
+    const allowedLSP3Formats = [
+      lsp3ProfileJson.LSP3Profile,
+      { json: lsp3ProfileJson, url: 'ipfs://QmbKvCVEePiDKxuouyty9bMsWBAxZDGr2jhxd4pLGLx95D' },
+    ];
 
-        const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
-          controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-          lsp3Profile: lsp3ProfileJson.LSP3Profile,
+    allowedLSP3Formats.forEach((lsp3ProfileMetadata) => {
+      describe('passing metadata to be uploaded', () => {
+        it('should deploy and set LSP3Profile data', async () => {
+          signer = signers[0];
+
+          const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
+            controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
+            lsp3Profile: lsp3ProfileMetadata,
+          });
+
+          universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
+
+          const data = await universalProfile.getData([
+            '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+          ]);
+
+          expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+          expect(data[0]).toEqual(expectedLSP3Value);
         });
-
-        universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
-
-        const data = await universalProfile.getData([
-          '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-        ]);
-
-        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
-        expect(data[0]).toEqual(expectedLSP3Value);
-      });
-    });
-
-    describe('passing metadata ready for encoding', () => {
-      it('should allow passing url and json', async () => {
-        signer = signers[0];
-
-        const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
-          controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-          lsp3Profile: {
-            json: lsp3ProfileJson,
-            url: 'ipfs://QmbKvCVEePiDKxuouyty9bMsWBAxZDGr2jhxd4pLGLx95D',
-          },
-        });
-
-        universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
-
-        const data = await universalProfile.getData([
-          '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-        ]);
-
-        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
-        expect(data[0]).toEqual(expectedLSP3Value);
       });
     });
   });

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -14,7 +14,7 @@ import {
   ProfileDataBeforeUpload,
   ProfileDeploymentOptions,
 } from '../interfaces';
-import { LSP3ProfileDataForEncoding } from '../interfaces/lsp3-profile';
+import { ProfileDataForEncoding } from '../interfaces/lsp3-profile';
 import {
   ContractDeploymentOptionsNonReactive,
   ContractDeploymentOptionsReactive,
@@ -224,7 +224,7 @@ export class LSP3UniversalProfile {
   static async uploadProfileData(
     profileData: ProfileDataBeforeUpload,
     uploadOptions?: UploadOptions
-  ): Promise<LSP3ProfileDataForEncoding> {
+  ): Promise<ProfileDataForEncoding> {
     uploadOptions = uploadOptions || defaultUploadOptions;
     const [profileImage, backgroundImage] = await Promise.all([
       prepareMetadataImage(uploadOptions, profileData.profileImage),
@@ -247,7 +247,7 @@ export class LSP3UniversalProfile {
     }
 
     return {
-      profile,
+      json: profile,
       url: uploadResponse.cid ? 'ipfs://' + uploadResponse.cid : 'https upload TBD',
     };
   }

--- a/src/lib/classes/lsp4-digital-asset-metadata.ts
+++ b/src/lib/classes/lsp4-digital-asset-metadata.ts
@@ -3,7 +3,7 @@ import { ipfsUpload, prepareMetadataAsset, prepareMetadataImage } from '../helpe
 import { LSPFactoryOptions } from '../interfaces';
 import {
   LSP4MetadataBeforeUpload,
-  LSP4MetadataForEncoding,
+  LSP4MetadataUrlForEncoding,
 } from '../interfaces/lsp4-digital-asset';
 import { UploadOptions } from '../interfaces/profile-upload-options';
 
@@ -17,7 +17,7 @@ export class LSP4DigitalAssetMetadata {
   static async uploadMetadata(
     metaData: LSP4MetadataBeforeUpload,
     uploadOptions?: UploadOptions
-  ): Promise<LSP4MetadataForEncoding> {
+  ): Promise<LSP4MetadataUrlForEncoding> {
     uploadOptions = uploadOptions || defaultUploadOptions;
 
     const [images, assets, icon] = await Promise.all([
@@ -51,7 +51,7 @@ export class LSP4DigitalAssetMetadata {
     }
 
     return {
-      lsp4Metadata: lsp4Metadata,
+      json: lsp4Metadata,
       url: uploadResponse.cid ? 'ipfs://' + uploadResponse.cid : 'https upload TBD',
     };
   }

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -192,45 +192,56 @@ describe('LSP7DigitalAsset', () => {
     const controllerAddress = '0xaDa25A4424b08F5337DacD619D4bCb21536a9B95';
     const name = 'TOKEN';
     const symbol = 'TKN';
+    const expectedLSP4Value =
+      '0x6f357c6a88c86e704ea6cb386d5952122035901f5ea5bb4a695b17d3fccc845d84032b0d697066733a2f2f516d5272714254514c33683256633950454c33643138566e526b6e7a73744547564378685657366a50615a7a5346';
 
-    it('should deploy lsp7 with metadata', async () => {
-      const lspFactory = new LSPFactory(provider, signer);
-      const lsp7DigitalAsset = await lspFactory.LSP7DigitalAsset.deploy({
-        controllerAddress,
-        isNFT: false,
-        name,
-        symbol,
-        digitalAssetMetadata: lsp4DigitalAsset.LSP4Metadata,
+    const allowedLSP4Formats = [
+      lsp4DigitalAsset.LSP4Metadata,
+      { json: lsp4DigitalAsset, url: 'ipfs://QmRrqBTQL3h2Vc9PEL3d18VnRknzstEGVCxhVW6jPaZzSF' },
+    ];
+
+    allowedLSP4Formats.forEach((lsp4Metadata) => {
+      it('should deploy lsp7 with metadata', async () => {
+        const lspFactory = new LSPFactory(provider, signer);
+        const lsp7DigitalAsset = await lspFactory.LSP7DigitalAsset.deploy({
+          controllerAddress,
+          isNFT: false,
+          name,
+          symbol,
+          digitalAssetMetadata: lsp4Metadata,
+        });
+
+        expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
+        expect(Object.keys(lsp7DigitalAsset).length).toEqual(2);
+
+        digitalAsset = LSP7Mintable__factory.connect(
+          lsp7DigitalAsset.LSP7DigitalAsset.address,
+          signer
+        );
       });
+      it('should deploy and set LSP4DigitalAsset data', async () => {
+        const ownerAddress = await digitalAsset.owner();
+        expect(ownerAddress).toEqual(controllerAddress);
 
-      expect(lsp7DigitalAsset.LSP7DigitalAsset.address).toBeDefined();
-      expect(Object.keys(lsp7DigitalAsset).length).toEqual(2);
+        const data = await digitalAsset.getData([
+          '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e',
+        ]);
 
-      digitalAsset = LSP7Mintable__factory.connect(
-        lsp7DigitalAsset.LSP7DigitalAsset.address,
-        signer
-      );
-    });
-    it('should deploy and set LSP4DigitalAsset data', async () => {
-      const ownerAddress = await digitalAsset.owner();
-      expect(ownerAddress).toEqual(controllerAddress);
+        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+        expect(data[0]).toEqual(expectedLSP4Value);
+      });
+      it('should have correct name and symbol set', async () => {
+        const [retrievedName, retrievedSymbol] = await digitalAsset.getData([
+          '0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1',
+          '0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756',
+        ]);
 
-      const data = await digitalAsset.getData([
-        '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e',
-      ]);
-
-      expect(data[0].startsWith('0x6f357c6a')).toBe(true);
-    });
-    it('should have correct name and symbol set', async () => {
-      const [retrievedName, retrievedSymbol] = await digitalAsset.getData([
-        '0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1',
-        '0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756',
-      ]);
-
-      expect(ethers.utils.toUtf8String(retrievedName)).toEqual(name);
-      expect(ethers.utils.toUtf8String(retrievedSymbol)).toEqual(symbol);
+        expect(ethers.utils.toUtf8String(retrievedName)).toEqual(name);
+        expect(ethers.utils.toUtf8String(retrievedSymbol)).toEqual(symbol);
+      });
     });
   });
+
   describe('deploy lsp7 with specified creators', () => {
     let digitalAsset: LSP7Mintable;
     const controllerAddress = '0xaDa25A4424b08F5337DacD619D4bCb21536a9B95';

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -232,99 +232,109 @@ describe('LSP8IdentifiableDigitalAsset', () => {
     const controllerAddress = '0xaDa25A4424b08F5337DacD619D4bCb21536a9B95';
     const name = 'TOKEN';
     const symbol = 'TKN';
+    const expectedLSP4Value =
+      '0x6f357c6a88c86e704ea6cb386d5952122035901f5ea5bb4a695b17d3fccc845d84032b0d697066733a2f2f516d5272714254514c33683256633950454c33643138566e526b6e7a73744547564378685657366a50615a7a5346';
 
-    it('should deploy lsp8 with metadata', async () => {
-      const lspFactory = new LSPFactory(provider, signer);
-      const lsp8DigitalAsset = await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
-        controllerAddress,
-        name,
-        symbol,
-        digitalAssetMetadata: lsp4DigitalAsset.LSP4Metadata,
-      });
-
-      expect(lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
-      expect(Object.keys(lsp8DigitalAsset).length).toEqual(2);
-
-      digitalAsset = LSP8Mintable__factory.connect(
-        lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address,
-        signer
-      );
-    });
-    it('should deploy and set LSP4DigitalAsset data', async () => {
-      const ownerAddress = await digitalAsset.owner();
-      expect(ownerAddress).toEqual(controllerAddress);
-
-      const data = await digitalAsset.getData([
-        '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e',
-      ]);
-
-      expect(data[0].startsWith('0x6f357c6a')).toBe(true);
-    });
-    it('should have correct name and symbol set', async () => {
-      const [retrievedName, retrievedSymbol] = await digitalAsset.getData([
-        '0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1',
-        '0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756',
-      ]);
-
-      expect(ethers.utils.toUtf8String(retrievedName)).toEqual(name);
-      expect(ethers.utils.toUtf8String(retrievedSymbol)).toEqual(symbol);
-    });
-  });
-  describe('deploy lsp8 with specified creators', () => {
-    let digitalAsset: LSP8Mintable;
-    const controllerAddress = '0xaDa25A4424b08F5337DacD619D4bCb21536a9B95';
-    const name = 'TOKEN';
-    const symbol = 'TKN';
-    const creators = [
-      '0xFCA72D5763b8cFc686C2285099D5F35a2F094E9f',
-      '0x591c236982b089Ad4B60758C075fA50Ec53CD674',
+    const allowedLSP4Formats = [
+      lsp4DigitalAsset.LSP4Metadata,
+      { json: lsp4DigitalAsset, url: 'ipfs://QmRrqBTQL3h2Vc9PEL3d18VnRknzstEGVCxhVW6jPaZzSF' },
     ];
 
-    it('should deploy with specified creators', async () => {
-      const lspFactory = new LSPFactory(provider, signer);
-      const lsp8DigitalAsset = await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
-        controllerAddress,
-        name,
-        symbol,
-        creators,
+    allowedLSP4Formats.forEach((lsp4Metadata) => {
+      it('should deploy lsp8 with metadata', async () => {
+        const lspFactory = new LSPFactory(provider, signer);
+        const lsp8DigitalAsset = await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
+          controllerAddress,
+          name,
+          symbol,
+          digitalAssetMetadata: lsp4Metadata,
+        });
+
+        expect(lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
+        expect(Object.keys(lsp8DigitalAsset).length).toEqual(2);
+
+        digitalAsset = LSP8Mintable__factory.connect(
+          lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address,
+          signer
+        );
       });
+      it('should deploy and set LSP4DigitalAsset data', async () => {
+        const ownerAddress = await digitalAsset.owner();
+        expect(ownerAddress).toEqual(controllerAddress);
 
-      expect(lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
-      expect(Object.keys(lsp8DigitalAsset).length).toEqual(2);
+        const data = await digitalAsset.getData([
+          '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e',
+        ]);
 
-      digitalAsset = LSP8Mintable__factory.connect(
-        lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address,
-        signer
-      );
+        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+        expect(data[0]).toEqual(expectedLSP4Value);
+      });
+      it('should have correct name and symbol set', async () => {
+        const [retrievedName, retrievedSymbol] = await digitalAsset.getData([
+          '0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1',
+          '0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756',
+        ]);
+
+        expect(ethers.utils.toUtf8String(retrievedName)).toEqual(name);
+        expect(ethers.utils.toUtf8String(retrievedSymbol)).toEqual(symbol);
+      });
     });
-    it('should have LSP4Creators[] set correctly', async () => {
-      const [creatorArrayLength] = await digitalAsset.getData([LSP4_KEYS.LSP4_CREATORS_ARRAY]);
-      expect(creatorArrayLength).toEqual(
-        '0x0000000000000000000000000000000000000000000000000000000000000002'
-      );
+    describe('deploy lsp8 with specified creators', () => {
+      let digitalAsset: LSP8Mintable;
+      const controllerAddress = '0xaDa25A4424b08F5337DacD619D4bCb21536a9B95';
+      const name = 'TOKEN';
+      const symbol = 'TKN';
+      const creators = [
+        '0xFCA72D5763b8cFc686C2285099D5F35a2F094E9f',
+        '0x591c236982b089Ad4B60758C075fA50Ec53CD674',
+      ];
 
-      const [creator1, creator2] = await digitalAsset.getData([
-        LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
-          ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 16).substring(2),
-        LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
-          ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 16).substring(2),
-      ]);
+      it('should deploy with specified creators', async () => {
+        const lspFactory = new LSPFactory(provider, signer);
+        const lsp8DigitalAsset = await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
+          controllerAddress,
+          name,
+          symbol,
+          creators,
+        });
 
-      expect(ethers.utils.getAddress(creator1)).toEqual(creators[0]);
-      expect(ethers.utils.getAddress(creator2)).toEqual(creators[1]);
-    });
-    it('should have LSP4CreatorsMap set correctly', async () => {
-      const creatorMap = await digitalAsset.getData([
-        LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[0].slice(2),
-        LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[1].slice(2),
-      ]);
+        expect(lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address).toBeDefined();
+        expect(Object.keys(lsp8DigitalAsset).length).toEqual(2);
 
-      expect(creatorMap[0]).toEqual(
-        ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
-      );
-      expect(creatorMap[1]).toEqual(
-        ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
-      );
+        digitalAsset = LSP8Mintable__factory.connect(
+          lsp8DigitalAsset.LSP8IdentifiableDigitalAsset.address,
+          signer
+        );
+      });
+      it('should have LSP4Creators[] set correctly', async () => {
+        const [creatorArrayLength] = await digitalAsset.getData([LSP4_KEYS.LSP4_CREATORS_ARRAY]);
+        expect(creatorArrayLength).toEqual(
+          '0x0000000000000000000000000000000000000000000000000000000000000002'
+        );
+
+        const [creator1, creator2] = await digitalAsset.getData([
+          LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
+            ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 16).substring(2),
+          LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
+            ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 16).substring(2),
+        ]);
+
+        expect(ethers.utils.getAddress(creator1)).toEqual(creators[0]);
+        expect(ethers.utils.getAddress(creator2)).toEqual(creators[1]);
+      });
+      it('should have LSP4CreatorsMap set correctly', async () => {
+        const creatorMap = await digitalAsset.getData([
+          LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[0].slice(2),
+          LSP4_KEYS.LSP4_CREATORS_MAP_PREFIX + creators[1].slice(2),
+        ]);
+
+        expect(creatorMap[0]).toEqual(
+          ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
+        );
+        expect(creatorMap[1]).toEqual(
+          ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 8) + ERC725_ACCOUNT_INTERRFACE.slice(2)
+        );
+      });
     });
   });
 });

--- a/src/lib/helpers/erc725.helper.ts
+++ b/src/lib/helpers/erc725.helper.ts
@@ -1,6 +1,9 @@
 import { ERC725, ERC725JSONSchema } from '@erc725/erc725.js';
 import { providers } from 'ethers';
 
+import { LSP3ProfileDataForEncoding } from '../interfaces/lsp3-profile';
+import { LSP4MetadataForEncoding } from '../interfaces/lsp4-digital-asset';
+
 export const schema: ERC725JSONSchema[] = [
   {
     name: 'LSP3Profile',
@@ -26,7 +29,11 @@ export function getERC725(address?: string, provider?: providers.Web3Provider) {
   return new ERC725(schema);
 }
 
-export function erc725EncodeData(lsp3Profile) {
+export function erc725EncodeData(
+  lsp3Profile:
+    | { LSP4Metadata: LSP4MetadataForEncoding }
+    | { LSP3Profile: LSP3ProfileDataForEncoding }
+) {
   const myERC725 = getERC725();
   return myERC725.encodeData(lsp3Profile);
 }

--- a/src/lib/helpers/erc725.helper.ts
+++ b/src/lib/helpers/erc725.helper.ts
@@ -30,10 +30,8 @@ export function getERC725(address?: string, provider?: providers.Web3Provider) {
 }
 
 export function erc725EncodeData(
-  lsp3Profile:
-    | { LSP4Metadata: LSP4MetadataForEncoding }
-    | { LSP3Profile: LSP3ProfileDataForEncoding }
+  data: { LSP4Metadata: LSP4MetadataForEncoding } | { LSP3Profile: LSP3ProfileDataForEncoding }
 ) {
   const myERC725 = getERC725();
-  return myERC725.encodeData(lsp3Profile);
+  return myERC725.encodeData(data);
 }

--- a/src/lib/helpers/erc725.helper.ts
+++ b/src/lib/helpers/erc725.helper.ts
@@ -1,7 +1,6 @@
 import { ERC725, ERC725JSONSchema } from '@erc725/erc725.js';
 import { providers } from 'ethers';
 
-import { LSP3ProfileJSON } from '../interfaces';
 import { LSP4DigitalAssetJSON } from '../interfaces/lsp4-digital-asset';
 
 export const schema: ERC725JSONSchema[] = [
@@ -29,14 +28,9 @@ export function getERC725(address?: string, provider?: providers.Web3Provider) {
   return new ERC725(schema);
 }
 
-export function encodeLSP3Profile(lsp3ProfileJson: LSP3ProfileJSON, url: string) {
+export function erc725EncodeData(lsp3Profile) {
   const myERC725 = getERC725();
-  return myERC725.encodeData({
-    LSP3Profile: {
-      json: lsp3ProfileJson,
-      url,
-    },
-  });
+  return myERC725.encodeData(lsp3Profile);
 }
 
 export function encodeLSP4Metadata(lsp4MetadataJSON: LSP4DigitalAssetJSON, url: string) {

--- a/src/lib/helpers/erc725.helper.ts
+++ b/src/lib/helpers/erc725.helper.ts
@@ -1,8 +1,6 @@
 import { ERC725, ERC725JSONSchema } from '@erc725/erc725.js';
 import { providers } from 'ethers';
 
-import { LSP4DigitalAssetJSON } from '../interfaces/lsp4-digital-asset';
-
 export const schema: ERC725JSONSchema[] = [
   {
     name: 'LSP3Profile',
@@ -31,14 +29,4 @@ export function getERC725(address?: string, provider?: providers.Web3Provider) {
 export function erc725EncodeData(lsp3Profile) {
   const myERC725 = getERC725();
   return myERC725.encodeData(lsp3Profile);
-}
-
-export function encodeLSP4Metadata(lsp4MetadataJSON: LSP4DigitalAssetJSON, url: string) {
-  const myERC725 = getERC725();
-  return myERC725.encodeData({
-    LSP4Metadata: {
-      json: lsp4MetadataJSON,
-      url,
-    },
-  });
 }

--- a/src/lib/helpers/uploader.helper.ts
+++ b/src/lib/helpers/uploader.helper.ts
@@ -139,7 +139,11 @@ export async function prepareMetadataAsset(
 // }
 
 export function isMetadataEncoded(metdata: string): boolean {
-  if (!metdata.startsWith('ipfs://') && !metdata.startsWith('https://')) {
+  if (
+    metdata.startsWith('0x') &&
+    !metdata.startsWith('ipfs://') &&
+    !metdata.startsWith('https://')
+  ) {
     return true;
   }
 

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -1,4 +1,4 @@
-import { LSP4MetadataBeforeUpload } from './lsp4-digital-asset';
+import { LSP4MetadataBeforeUpload, LSP4MetadataForEncoding } from './lsp4-digital-asset';
 import { UploadOptions } from './profile-upload-options';
 
 import { DeployedContract } from '.';
@@ -12,7 +12,7 @@ export interface DigitalAssetDeploymentOptions {
   controllerAddress: string;
   name: string;
   symbol: string;
-  digitalAssetMetadata?: LSP4MetadataBeforeUpload | string;
+  digitalAssetMetadata?: LSP4MetadataBeforeUpload | LSP4MetadataForEncoding | string;
   creators?: string[];
 }
 

--- a/src/lib/interfaces/lsp3-profile.ts
+++ b/src/lib/interfaces/lsp3-profile.ts
@@ -36,7 +36,15 @@ export interface ProfileDataBeforeUpload {
   tags?: string[];
 }
 
-export interface LSP3ProfileDataForEncoding {
-  profile: LSP3ProfileJSON;
+export interface ProfileDataForEncoding {
+  json: LSP3ProfileJSON;
   url: string;
 }
+
+export interface HashedProfileDataForEncoding {
+  hashFunction: string;
+  hash: string;
+  url: string;
+}
+
+export type LSP3ProfileDataForEncoding = ProfileDataForEncoding | HashedProfileDataForEncoding;

--- a/src/lib/interfaces/lsp4-digital-asset.ts
+++ b/src/lib/interfaces/lsp4-digital-asset.ts
@@ -20,7 +20,15 @@ export interface LSP4MetadataBeforeUpload {
   assets?: (File | AssetBuffer | AssetMetadata)[];
 }
 
-export interface LSP4MetadataForEncoding {
-  lsp4Metadata: LSP4DigitalAssetJSON;
+export interface LSP4MetadataUrlForEncoding {
+  json: LSP4DigitalAssetJSON;
   url: string;
 }
+
+export interface HashedLSP4MetadataForEncoding {
+  hashFunction: string;
+  hash: string;
+  url: string;
+}
+
+export type LSP4MetadataForEncoding = LSP4MetadataUrlForEncoding | HashedLSP4MetadataForEncoding;

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -1,6 +1,6 @@
 import { DeployedContract } from '../..';
 
-import { ProfileDataBeforeUpload } from './lsp3-profile';
+import { LSP3ProfileDataForEncoding, ProfileDataBeforeUpload } from './lsp3-profile';
 import { UploadOptions } from './profile-upload-options';
 
 export enum ContractNames {
@@ -19,7 +19,7 @@ export interface ControllerOptions {
  */
 export interface ProfileDeploymentOptions {
   controllerAddresses: (string | ControllerOptions)[];
-  lsp3Profile?: ProfileDataBeforeUpload | string;
+  lsp3Profile?: ProfileDataBeforeUpload | LSP3ProfileDataForEncoding | string;
   baseContractAddresses?: {
     erc725Account?: string;
     universalReceiverDelegate?: string;

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -29,7 +29,7 @@ import {
   LSP4_KEYS,
 } from '../helpers/config.helper';
 import { deployContract, deployProxyContract, waitForReceipt } from '../helpers/deployment.helper';
-import { encodeLSP4Metadata } from '../helpers/erc725.helper';
+import { erc725EncodeData } from '../helpers/erc725.helper';
 import { isMetadataEncoded } from '../helpers/uploader.helper';
 import {
   DeploymentEvent$,
@@ -48,6 +48,7 @@ import {
   LSP4DigitalAssetJSON,
   LSP4MetadataBeforeUpload,
   LSP4MetadataForEncoding,
+  LSP4MetadataUrlForEncoding,
 } from '../interfaces/lsp4-digital-asset';
 import { UploadOptions } from '../interfaces/profile-upload-options';
 
@@ -338,7 +339,7 @@ function initializeLSP8Proxy(
 }
 
 export function lsp4MetadataUpload$(
-  lsp4Metadata: LSP4MetadataBeforeUpload | string,
+  lsp4Metadata: LSP4MetadataBeforeUpload | LSP4MetadataForEncoding | string,
   uploadOptions?: UploadOptions
 ) {
   let lsp4Metadata$: Observable<string>;
@@ -357,8 +358,8 @@ export function lsp4MetadataUpload$(
 export async function getLSP4MetadataUrl(
   lsp4Metadata: LSP4MetadataBeforeUpload | string,
   uploadOptions: UploadOptions
-): Promise<LSP4MetadataForEncoding> {
-  let lsp4MetadataForEncoding: LSP4MetadataForEncoding;
+): Promise<LSP4MetadataUrlForEncoding> {
+  let lsp4MetadataForEncoding: LSP4MetadataUrlForEncoding;
 
   if (typeof lsp4Metadata === 'string') {
     let lsp4JsonUrl = lsp4Metadata;
@@ -377,7 +378,7 @@ export async function getLSP4MetadataUrl(
 
     lsp4MetadataForEncoding = {
       url: lsp4Metadata,
-      lsp4Metadata: lsp4MetadataJSON as LSP4DigitalAssetJSON,
+      json: lsp4MetadataJSON as LSP4DigitalAssetJSON,
     };
   } else {
     lsp4MetadataForEncoding = await LSP4DigitalAssetMetadata.uploadMetadata(
@@ -390,15 +391,30 @@ export async function getLSP4MetadataUrl(
 }
 
 export async function getEncodedLSP4Metadata(
-  lsp4Metadata: LSP4MetadataBeforeUpload | string,
+  lsp4Metadata: LSP4MetadataBeforeUpload | LSP4MetadataForEncoding | string,
   uploadOptions: UploadOptions
 ): Promise<string> {
-  const lsp4MetadataForEncoding = await getLSP4MetadataUrl(lsp4Metadata, uploadOptions);
+  let lsp4MetadataForEncoding: LSP4MetadataForEncoding;
+  if (typeof lsp4Metadata === 'string' || 'description' in lsp4Metadata) {
+    lsp4MetadataForEncoding = await getLSP4MetadataUrl(lsp4Metadata, uploadOptions);
+  } else {
+    lsp4MetadataForEncoding = lsp4Metadata;
+  }
 
-  const encodedLSP4Metadata = encodeLSP4Metadata(
-    lsp4MetadataForEncoding.lsp4Metadata,
-    lsp4MetadataForEncoding.url
-  );
+  let encodedLSP4Metadata;
+
+  if ('hash' in lsp4MetadataForEncoding) {
+    encodedLSP4Metadata = erc725EncodeData({
+      LSP4Metadata: lsp4MetadataForEncoding,
+    });
+  } else {
+    encodedLSP4Metadata = erc725EncodeData({
+      LSP4Metadata: {
+        json: lsp4MetadataForEncoding.json,
+        url: lsp4MetadataForEncoding.url,
+      },
+    });
+  }
 
   return encodedLSP4Metadata.LSP4Metadata.value;
 }

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -401,20 +401,9 @@ export async function getEncodedLSP4Metadata(
     lsp4MetadataForEncoding = lsp4Metadata;
   }
 
-  let encodedLSP4Metadata;
-
-  if ('hash' in lsp4MetadataForEncoding) {
-    encodedLSP4Metadata = erc725EncodeData({
-      LSP4Metadata: lsp4MetadataForEncoding,
-    });
-  } else {
-    encodedLSP4Metadata = erc725EncodeData({
-      LSP4Metadata: {
-        json: lsp4MetadataForEncoding.json,
-        url: lsp4MetadataForEncoding.url,
-      },
-    });
-  }
+  const encodedLSP4Metadata = erc725EncodeData({
+    LSP4Metadata: lsp4MetadataForEncoding,
+  });
 
   return encodedLSP4Metadata.LSP4Metadata.value;
 }

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -254,18 +254,7 @@ async function getEncodedLSP3ProfileData(
     lsp3ProfileDataForEncoding = lsp3Profile;
   }
 
-  let encodedDataResult;
-
-  if ('hash' in lsp3ProfileDataForEncoding) {
-    encodedDataResult = erc725EncodeData({ LSP3Profile: lsp3ProfileDataForEncoding });
-  } else {
-    encodedDataResult = erc725EncodeData({
-      LSP3Profile: {
-        json: lsp3ProfileDataForEncoding.json,
-        url: lsp3ProfileDataForEncoding.url,
-      },
-    });
-  }
+  const encodedDataResult = erc725EncodeData({ LSP3Profile: lsp3ProfileDataForEncoding });
 
   return encodedDataResult.LSP3Profile.value;
 }

--- a/test/lsp3-profile.mock.ts
+++ b/test/lsp3-profile.mock.ts
@@ -1,4 +1,4 @@
-import { LSP3ProfileJSON } from '../interfaces/lsp3-profile';
+import { LSP3ProfileJSON } from '../src/lib/interfaces/lsp3-profile';
 
 export const lsp3ProfileJson: LSP3ProfileJSON = {
   LSP3Profile: {

--- a/test/lsp4-digital-asset.mock.ts
+++ b/test/lsp4-digital-asset.mock.ts
@@ -42,5 +42,8 @@ export const lsp4DigitalAsset: LSP4DigitalAssetJSON = {
         },
       ],
     ],
+    links: [],
+    assets: [],
+    icon: [],
   },
 };


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Feature

### What is the new behaviour (if this is a feature change)?
Pass metadata as an object as accepted by `encodeData` function of erc725.js. Bypasses upload and will go straight to erc725js for encoding
