### PR TITLE
improvement: deployment config version parameter

### DIFF
--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -1,6 +1,6 @@
+---
 sidebar_position: 3
 title: LSP7DigitalAsset
-
 ---
 
 # LSP7DigitalAsset
@@ -118,7 +118,7 @@ await lspFactory.LSP7DigitalAsset.deploy(
   },
   {
     deployReactive: true,
-  }
+  },
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);

--- a/docs/deployment/contract-deployment-options.md
+++ b/docs/deployment/contract-deployment-options.md
@@ -11,10 +11,8 @@ The `deploy` function takes an object `contractDeploymentOptions` as its second 
 
 The `contractDeploymentOptions?` is an `Object` with the following properties:
 
-- `version?`: The smart contract's version you want to deploy as `string`.
-- `byteCode?`: The custom bytecode to be deployed as `string`.
+- `version?`: The smart contract's version you want to deploy as `string`. Can be a version number, a base contract address or custom bytecode.
 - `deployProxy?`: `boolean` indicator used to determine if the contract will be deployed using a proxy contract (e.g., [EIP1167](https://eips.ethereum.org/EIPS/eip-1167)).
-- `libAddress?`: The address of a base contract for proxy deployment as `string` (e.g., [EIP1167](https://eips.ethereum.org/EIPS/eip-1167)).
 - `uploadOptions?`: Specification `Object` how the metadata should be uploaded.
 - `ipfsClientOptions?`: Optional IPFS Client Options as `Object` defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library used internally.
 
@@ -37,15 +35,15 @@ LSPFactory stores the base contract addresses for different versions [internally
 
 ## Custom Bytecode
 
-You can specify the bytecode you want your contract to use by providing the `byteCode` parameter. This will deploy a standalone contract from your custom bytecode without using a proxy.
+You can specify the bytecode you want your contract to use by providing custom bytecode to the `version` parameter. This will deploy a standalone contract from the supplied bytecode without using proxy deployment.
 
 For example, you could deploy a Universal Profile with a Key Manager that uses your custom bytecode:
 
-```javascript title="Deploying a Universal Profile with a custom Key Manager base contract"
+```javascript title="Deploying a Universal Profile with a custom Key Manager implementation"
 lspFactory.LSP3UniversalProfile.deploy({...}, {
     version: '0.4.1'
     KeyManager: {
-        bytecode: '0x...',
+        version: '0x...',
     }
 })
 ```
@@ -71,7 +69,7 @@ lspFactory.LSP3UniversalProfile.deploy({...}, {
 })
 ```
 
-You can also use a combination of the properties `libAddress`, `bytecode` and `version`.
+You can also use a combination of configurations for the Universal Profile deployment by passing a version number, custom bytecode or a custom base contract address to the version parameter.
 
 ```javascript title="Deploying a Universal Profile with specific contract deployment options"
 lspFactory.LSP3UniversalProfile.deploy({...}, {
@@ -79,10 +77,10 @@ lspFactory.LSP3UniversalProfile.deploy({...}, {
         version: '0.4.1',
     }
     UniversalRecieverDelegate: {
-        baseContract: '0x...'
+        version: '0x...'
     }
     KeyManager: {
-        libAddress: '0x6c1F3Ed2F99054C88897e2f32187ef15c62dC560'
+        version: '0x6c1F3Ed2F99054C88897e2f32187ef15c62dC560'
     }
 })
 ```
@@ -93,7 +91,7 @@ Because deploying an [`LSP7DigitalAsset`](../classes/lsp7-digital-asset) or an [
 
 ```javascript title="Deploying an LSP7 Digital Asset with a specified base contract address"
 lspFactory.LSP7DigitalAsset.deploy({...}, {
-    libAddress: '0xdD373889355d37D6cb9A5028Ce74cDBacC7CF782'
+    version: '0xdD373889355d37D6cb9A5028Ce74cDBacC7CF782'
 })
 ```
 
@@ -105,6 +103,6 @@ lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
 
 ```javascript title="Deploying specific bytecode for LSP8 Identifiable Digital Asset base contract"
 lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
-    bytecode: '0x...'
+    version: '0x...'
 })
 ```

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -371,7 +371,7 @@ describe('LSP3UniversalProfile', () => {
         deployedContracts = await testUPDeployment(
           {
             ERC725Account: {
-              byteCode: UniversalProfile__factory.bytecode,
+              version: UniversalProfile__factory.bytecode,
             },
           },
           4,
@@ -403,7 +403,7 @@ describe('LSP3UniversalProfile', () => {
 
         deployedContracts = await testUPDeployment(
           {
-            KeyManager: { byteCode: LSP6KeyManager__factory.bytecode },
+            KeyManager: { version: LSP6KeyManager__factory.bytecode },
           },
           4,
           lspFactory,
@@ -430,7 +430,7 @@ describe('LSP3UniversalProfile', () => {
         deployedContracts = await testUPDeployment(
           {
             UniversalReceiverDelegate: {
-              byteCode: LSP1UniversalReceiverDelegateUP__factory.bytecode,
+              version: LSP1UniversalReceiverDelegateUP__factory.bytecode,
             },
           },
           5,
@@ -471,7 +471,7 @@ describe('LSP3UniversalProfile', () => {
       it('should not deploy UP base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            ERC725Account: { libAddress: baseContracts.universalProfile.address },
+            ERC725Account: { version: baseContracts.universalProfile.address },
           },
           4,
           lspFactory,
@@ -500,7 +500,7 @@ describe('LSP3UniversalProfile', () => {
       it('should not deploy KeyManager base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            KeyManager: { libAddress: baseContracts.keyManager.address },
+            KeyManager: { version: baseContracts.keyManager.address },
           },
           4,
           lspFactory,
@@ -529,7 +529,7 @@ describe('LSP3UniversalProfile', () => {
         deployedContracts = await testUPDeployment(
           {
             UniversalReceiverDelegate: {
-              libAddress: baseContracts.universalReceiverDelegate.address,
+              version: baseContracts.universalReceiverDelegate.address,
             },
           },
           4,
@@ -561,7 +561,7 @@ describe('LSP3UniversalProfile', () => {
         deployedContracts = await testUPDeployment(
           {
             UniversalReceiverDelegate: {
-              libAddress: baseContracts.universalReceiverDelegate.address,
+              version: baseContracts.universalReceiverDelegate.address,
               deployProxy: true,
             },
           },

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -22,6 +22,7 @@ import {
   waitForBaseContractAddress$,
 } from '../services/base-contract.service';
 import {
+  convertConfigurationObject,
   lsp4MetadataUpload$,
   lsp7DigitalAssetDeployment$,
   setMetadataAndTransferOwnership$,
@@ -77,24 +78,28 @@ export class LSP7DigitalAsset {
     digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions,
     contractDeploymentOptions: T = undefined
   ): LSP7ObservableOrPromise<T> {
+    const digitalAssetConfiguration = contractDeploymentOptions
+      ? convertConfigurationObject(contractDeploymentOptions)
+      : null;
+
     const lsp4Metadata$ = lsp4MetadataUpload$(
       digitalAssetDeploymentOptions.digitalAssetMetadata,
-      contractDeploymentOptions?.uploadOptions ?? this.options.uploadOptions
+      digitalAssetConfiguration?.uploadOptions ?? this.options.uploadOptions
     );
 
     const defaultBaseContractAddress: string | undefined =
-      contractDeploymentOptions?.libAddress ??
+      digitalAssetConfiguration?.libAddress ??
       versions[this.options.chainId]?.contracts.LSP7Mintable?.versions[
-        contractDeploymentOptions?.version ?? DEFAULT_CONTRACT_VERSION
+        digitalAssetConfiguration?.version ?? DEFAULT_CONTRACT_VERSION
       ];
 
     const deployBaseContract$ = shouldDeployBaseContract$(
       this.options.provider,
       versions[this.options.chainId]?.contracts.LSP7Mintable?.baseContract,
-      contractDeploymentOptions?.deployProxy,
+      digitalAssetConfiguration?.deployProxy,
       defaultBaseContractAddress,
-      contractDeploymentOptions?.libAddress,
-      contractDeploymentOptions?.byteCode
+      digitalAssetConfiguration?.libAddress,
+      digitalAssetConfiguration?.byteCode
     );
 
     const baseContractDeployment$ = deployBaseContract$.pipe(
@@ -107,15 +112,15 @@ export class LSP7DigitalAsset {
     const baseContractAddress$ = waitForBaseContractAddress$(
       baseContractDeployment$,
       defaultBaseContractAddress,
-      contractDeploymentOptions?.deployProxy,
-      contractDeploymentOptions?.byteCode
+      digitalAssetConfiguration?.deployProxy,
+      digitalAssetConfiguration?.byteCode
     );
 
     const digitalAsset$ = lsp7DigitalAssetDeployment$(
       this.signer,
       digitalAssetDeploymentOptions,
       baseContractAddress$,
-      contractDeploymentOptions?.byteCode
+      digitalAssetConfiguration?.byteCode
     );
 
     const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
@@ -135,7 +140,7 @@ export class LSP7DigitalAsset {
       setLSP4AndTransferOwnership$,
     ]).pipe(concatAll());
 
-    if (contractDeploymentOptions?.deployReactive) return deployment$ as LSP7ObservableOrPromise<T>;
+    if (digitalAssetConfiguration?.deployReactive) return deployment$ as LSP7ObservableOrPromise<T>;
 
     return waitForContractDeployment$(deployment$) as LSP7ObservableOrPromise<T>;
   }

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -22,7 +22,7 @@ import {
   waitForBaseContractAddress$,
 } from '../services/base-contract.service';
 import {
-  convertConfigurationObject,
+  convertDigitalAssetConfigurationObject,
   lsp4MetadataUpload$,
   lsp7DigitalAssetDeployment$,
   setMetadataAndTransferOwnership$,
@@ -79,7 +79,7 @@ export class LSP7DigitalAsset {
     contractDeploymentOptions: T = undefined
   ): LSP7ObservableOrPromise<T> {
     const digitalAssetConfiguration = contractDeploymentOptions
-      ? convertConfigurationObject(contractDeploymentOptions)
+      ? convertDigitalAssetConfigurationObject(contractDeploymentOptions)
       : null;
 
     const lsp4Metadata$ = lsp4MetadataUpload$(

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -62,7 +62,7 @@ describe('LSP7DigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        libAddress: baseContract.address,
+        version: baseContract.address,
       }
     );
 
@@ -160,7 +160,7 @@ describe('LSP7DigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        byteCode: passedBytecode,
+        version: passedBytecode,
       }
     );
 

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -22,7 +22,7 @@ import {
   waitForBaseContractAddress$,
 } from '../services/base-contract.service';
 import {
-  convertConfigurationObject,
+  convertDigitalAssetConfigurationObject,
   lsp4MetadataUpload$,
   lsp8IdentifiableDigitalAssetDeployment$,
   setMetadataAndTransferOwnership$,
@@ -78,7 +78,7 @@ export class LSP8IdentifiableDigitalAsset {
     contractDeploymentOptions?: T
   ): LSP8ObservableOrPromise<T> {
     const digitalAssetConfiguration = contractDeploymentOptions
-      ? convertConfigurationObject(contractDeploymentOptions)
+      ? convertDigitalAssetConfigurationObject(contractDeploymentOptions)
       : null;
 
     const lsp4Metadata$ = lsp4MetadataUpload$(

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -22,6 +22,7 @@ import {
   waitForBaseContractAddress$,
 } from '../services/base-contract.service';
 import {
+  convertConfigurationObject,
   lsp4MetadataUpload$,
   lsp8IdentifiableDigitalAssetDeployment$,
   setMetadataAndTransferOwnership$,
@@ -76,24 +77,28 @@ export class LSP8IdentifiableDigitalAsset {
     digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
     contractDeploymentOptions?: T
   ): LSP8ObservableOrPromise<T> {
+    const digitalAssetConfiguration = contractDeploymentOptions
+      ? convertConfigurationObject(contractDeploymentOptions)
+      : null;
+
     const lsp4Metadata$ = lsp4MetadataUpload$(
       digitalAssetDeploymentOptions.digitalAssetMetadata,
-      contractDeploymentOptions?.uploadOptions ?? this.options.uploadOptions
+      digitalAssetConfiguration?.uploadOptions ?? this.options.uploadOptions
     );
 
     const defaultBaseContractAddress: string | undefined =
-      contractDeploymentOptions?.libAddress ??
+      digitalAssetConfiguration?.libAddress ??
       versions[this.options.chainId]?.contracts.LSP8Mintable?.versions[
-        contractDeploymentOptions?.version ?? DEFAULT_CONTRACT_VERSION
+        digitalAssetConfiguration?.version ?? DEFAULT_CONTRACT_VERSION
       ];
 
     const deployBaseContract$ = shouldDeployBaseContract$(
       this.options.provider,
       versions[this.options.chainId]?.contracts.LSP8Mintable?.baseContract,
-      contractDeploymentOptions?.deployProxy,
+      digitalAssetConfiguration?.deployProxy,
       defaultBaseContractAddress,
-      contractDeploymentOptions?.libAddress,
-      contractDeploymentOptions?.byteCode
+      digitalAssetConfiguration?.libAddress,
+      digitalAssetConfiguration?.byteCode
     );
 
     const baseContractDeployment$ = deployBaseContract$.pipe(
@@ -106,15 +111,15 @@ export class LSP8IdentifiableDigitalAsset {
     const baseContractAddress$ = waitForBaseContractAddress$(
       baseContractDeployment$,
       defaultBaseContractAddress,
-      contractDeploymentOptions?.deployProxy,
-      contractDeploymentOptions?.byteCode
+      digitalAssetConfiguration?.deployProxy,
+      digitalAssetConfiguration?.byteCode
     );
 
     const digitalAsset$ = lsp8IdentifiableDigitalAssetDeployment$(
       this.signer,
       digitalAssetDeploymentOptions,
       baseContractAddress$,
-      contractDeploymentOptions?.byteCode
+      digitalAssetConfiguration?.byteCode
     );
 
     const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
@@ -134,7 +139,7 @@ export class LSP8IdentifiableDigitalAsset {
       setLSP4AndTransferOwnership$,
     ]).pipe(concatAll());
 
-    if (contractDeploymentOptions?.deployReactive) return deployment$ as LSP8ObservableOrPromise<T>;
+    if (digitalAssetConfiguration?.deployReactive) return deployment$ as LSP8ObservableOrPromise<T>;
 
     return waitForContractDeployment$(deployment$) as LSP8ObservableOrPromise<T>;
   }

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -60,7 +60,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        libAddress: baseContract.address,
+        version: baseContract.address,
       }
     );
 
@@ -193,7 +193,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        byteCode: passedBytecode,
+        version: passedBytecode,
       }
     );
 

--- a/src/lib/helpers/deployment.helper.ts
+++ b/src/lib/helpers/deployment.helper.ts
@@ -1,4 +1,5 @@
 import { Contract, ContractFactory, ContractInterface, providers, Signer } from 'ethers';
+import { getAddress } from 'ethers/lib/utils';
 import { lastValueFrom, Observable } from 'rxjs';
 import { catchError, scan, shareReplay, switchMap, takeLast } from 'rxjs/operators';
 
@@ -200,4 +201,13 @@ export function waitForContractDeployment$(deployment$: Observable<DeploymentEve
       shareReplay()
     )
   );
+}
+
+export function isAddress(testAddress: string) {
+  try {
+    getAddress(testAddress);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/helpers/deployment.helper.ts
+++ b/src/lib/helpers/deployment.helper.ts
@@ -211,3 +211,19 @@ export function isAddress(testAddress: string) {
     return false;
   }
 }
+
+export function convertContractDeploymentOptionsVersion(providedVersion?: string) {
+  let version: string, byteCode: string, libAddress: string;
+
+  if (providedVersion && providedVersion.startsWith('0x')) {
+    if (isAddress(providedVersion)) {
+      libAddress = providedVersion;
+    } else {
+      byteCode = providedVersion;
+    }
+  } else if (providedVersion) {
+    version = providedVersion;
+  }
+
+  return { version, byteCode, libAddress };
+}

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -30,8 +30,6 @@ export interface DeployedLSP7DigitalAsset {
 
 interface ContractDeploymentOptionsBase {
   version?: string;
-  byteCode?: string;
-  libAddress?: string;
   deployProxy?: boolean;
   uploadOptions?: UploadOptions;
 }
@@ -46,3 +44,12 @@ export interface ContractDeploymentOptionsNonReactive extends ContractDeployment
 export type ContractDeploymentOptions =
   | ContractDeploymentOptionsReactive
   | ContractDeploymentOptionsNonReactive;
+
+export interface DigitalAssetConfiguration {
+  version?: string;
+  byteCode?: string;
+  libAddress?: string;
+  deployProxy?: boolean;
+  uploadOptions?: UploadOptions;
+  deployReactive: boolean;
+}

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -1,6 +1,6 @@
 import { DeployedContract } from '../..';
 
-import { LSP3ProfileDataForEncoding, ProfileDataBeforeUpload } from './lsp3-profile';
+import { ProfileDataBeforeUpload } from './lsp3-profile';
 import { UploadOptions } from './profile-upload-options';
 
 export enum ContractNames {
@@ -19,12 +19,12 @@ export interface ControllerOptions {
  */
 export interface ProfileDeploymentOptions {
   controllerAddresses: (string | ControllerOptions)[];
-  lsp3Profile?: ProfileDataBeforeUpload | LSP3ProfileDataForEncoding | string;
   baseContractAddresses?: {
     erc725Account?: string;
     universalReceiverDelegate?: string;
     keyManager?: string;
   };
+  lsp3Profile?: ProfileDataBeforeUpload | string;
 }
 export interface DeployedContracts {
   ERC725Account?: DeployedContract;
@@ -43,9 +43,7 @@ export interface BaseContractAddresses {
 
 interface ContractOptions {
   version?: string;
-  byteCode?: string;
   deployProxy?: boolean;
-  libAddress?: string;
 }
 
 interface ContractDeploymentOptionsBase {
@@ -67,3 +65,19 @@ export interface ContractDeploymentOptionsNonReactive extends ContractDeployment
 export type ContractDeploymentOptions =
   | ContractDeploymentOptionsReactive
   | ContractDeploymentOptionsNonReactive;
+
+interface ContractConfiguration {
+  version?: string;
+  byteCode?: string;
+  libAddress?: string;
+  deployProxy?: boolean;
+}
+
+export interface UniversalProfileDeploymentConfiguration {
+  version?: string;
+  uploadOptions?: UploadOptions;
+  ERC725Account?: ContractConfiguration;
+  KeyManager?: ContractConfiguration;
+  UniversalReceiverDelegate?: ContractConfiguration;
+  deployReactive: boolean;
+}

--- a/src/lib/services/base-contract.service.ts
+++ b/src/lib/services/base-contract.service.ts
@@ -10,8 +10,8 @@ import {
   LSP6KeyManagerInit__factory,
   LSP7MintableInit__factory,
   LSP8MintableInit__factory,
-  ContractDeploymentOptions as ProfileContractDeploymentOptions,
   ContractNames as UniversalProfileContractNames,
+  UniversalProfileDeploymentConfiguration,
   UniversalProfileInit__factory,
 } from '../..';
 import contractVersions from '../../versions.json';
@@ -155,7 +155,7 @@ export function shouldDeployUniversalProfileBaseContracts$(
   defaultKeyManagerBaseContractAddress: string,
   provider: providers.Web3Provider | providers.JsonRpcProvider,
   chainId: number,
-  contractDeploymentOptions?: ProfileContractDeploymentOptions
+  contractDeploymentOptions?: UniversalProfileDeploymentConfiguration
 ) {
   return forkJoin([
     shouldDeployBaseContract$(
@@ -189,7 +189,7 @@ export function universalProfileBaseContractAddresses$(
   baseContractDeployment$: Observable<DeploymentEventContract>,
   defaultUPBaseContractAddress: string,
   defaultKeyManagerBaseContractAddress: string,
-  contractDeploymentOptions?: ProfileContractDeploymentOptions,
+  contractDeploymentOptions?: UniversalProfileDeploymentConfiguration,
   deployUniversalReceiverProxy?: boolean
 ) {
   const providedUPBaseContractAddress = contractDeploymentOptions?.ERC725Account?.libAddress;

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -28,7 +28,12 @@ import {
   GAS_PRICE,
   LSP4_KEYS,
 } from '../helpers/config.helper';
-import { deployContract, deployProxyContract, waitForReceipt } from '../helpers/deployment.helper';
+import {
+  deployContract,
+  deployProxyContract,
+  isAddress,
+  waitForReceipt,
+} from '../helpers/deployment.helper';
 import { erc725EncodeData } from '../helpers/erc725.helper';
 import { isMetadataEncoded } from '../helpers/uploader.helper';
 import {
@@ -40,7 +45,9 @@ import {
   DeploymentType,
 } from '../interfaces';
 import {
+  ContractDeploymentOptions,
   ContractNames,
+  DigitalAssetConfiguration,
   DigitalAssetDeploymentOptions,
   LSP7DigitalAssetDeploymentOptions,
 } from '../interfaces/digital-asset-deployment';
@@ -602,4 +609,34 @@ async function transferOwnership(
     console.error('Error when transferring ownership');
     throw error;
   }
+}
+
+export function convertConfigurationObject(
+  contractDeploymentOptions?: ContractDeploymentOptions
+): DigitalAssetConfiguration {
+  let version: string;
+  let byteCode: string;
+  let libAddress: string;
+
+  if (
+    contractDeploymentOptions?.version &&
+    contractDeploymentOptions?.version.slice(0, 2) === '0x'
+  ) {
+    if (isAddress(contractDeploymentOptions?.version)) {
+      libAddress = contractDeploymentOptions?.version;
+    } else {
+      byteCode = contractDeploymentOptions?.version;
+    }
+  } else if (contractDeploymentOptions?.version) {
+    version = contractDeploymentOptions?.version;
+  }
+
+  return {
+    deployProxy: contractDeploymentOptions?.deployProxy,
+    uploadOptions: contractDeploymentOptions?.uploadOptions,
+    deployReactive: contractDeploymentOptions?.deployReactive,
+    version,
+    byteCode,
+    libAddress,
+  };
 }

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -29,9 +29,9 @@ import {
   LSP4_KEYS,
 } from '../helpers/config.helper';
 import {
+  convertContractDeploymentOptionsVersion,
   deployContract,
   deployProxyContract,
-  isAddress,
   waitForReceipt,
 } from '../helpers/deployment.helper';
 import { erc725EncodeData } from '../helpers/erc725.helper';
@@ -611,25 +611,12 @@ async function transferOwnership(
   }
 }
 
-export function convertConfigurationObject(
+export function convertDigitalAssetConfigurationObject(
   contractDeploymentOptions?: ContractDeploymentOptions
 ): DigitalAssetConfiguration {
-  let version: string;
-  let byteCode: string;
-  let libAddress: string;
-
-  if (
-    contractDeploymentOptions?.version &&
-    contractDeploymentOptions?.version.slice(0, 2) === '0x'
-  ) {
-    if (isAddress(contractDeploymentOptions?.version)) {
-      libAddress = contractDeploymentOptions?.version;
-    } else {
-      byteCode = contractDeploymentOptions?.version;
-    }
-  } else if (contractDeploymentOptions?.version) {
-    version = contractDeploymentOptions?.version;
-  }
+  const { version, byteCode, libAddress } = convertContractDeploymentOptionsVersion(
+    contractDeploymentOptions?.version
+  );
 
   return {
     deployProxy: contractDeploymentOptions?.deployProxy,

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -19,6 +19,7 @@ import {
   PREFIX_PERMISSIONS,
 } from '../helpers/config.helper';
 import {
+  convertContractDeploymentOptionsVersion,
   deployContract,
   getProxyByteCode,
   initialize,
@@ -28,6 +29,7 @@ import { erc725EncodeData } from '../helpers/erc725.helper';
 import { isMetadataEncoded } from '../helpers/uploader.helper';
 import {
   BaseContractAddresses,
+  ContractDeploymentOptions,
   ContractNames,
   ControllerOptions,
   DeploymentEvent$,
@@ -38,6 +40,7 @@ import {
   DeploymentType,
   LSP3ProfileJSON,
   ProfileDataBeforeUpload,
+  UniversalProfileDeploymentConfiguration,
 } from '../interfaces';
 import { LSP3ProfileDataForEncoding, ProfileDataForEncoding } from '../interfaces/lsp3-profile';
 import { UploadOptions } from '../interfaces/profile-upload-options';
@@ -481,4 +484,52 @@ export function isSignerUniversalProfile$(signer: Signer) {
 
     return false;
   }).pipe(shareReplay());
+}
+
+export function convertUniversalProfileConfigurationObject(
+  contractDeploymentOptions: ContractDeploymentOptions
+): UniversalProfileDeploymentConfiguration {
+  const {
+    version: erc725AccountVersion,
+    byteCode: erc725AccountBytecode,
+    libAddress: erc725AccountLibAddress,
+  } = convertContractDeploymentOptionsVersion(contractDeploymentOptions?.ERC725Account?.version);
+
+  const {
+    version: keyManagerVersion,
+    byteCode: keyManagerBytecode,
+    libAddress: keyManagerLibAddress,
+  } = convertContractDeploymentOptionsVersion(contractDeploymentOptions?.KeyManager?.version);
+
+  const {
+    version: universalReceiverDelegateVersion,
+    byteCode: universalReceiverDelegateBytecode,
+    libAddress: universalReceiverDelegateLibAddress,
+  } = convertContractDeploymentOptionsVersion(
+    contractDeploymentOptions?.UniversalReceiverDelegate?.version
+  );
+
+  return {
+    version: contractDeploymentOptions?.version,
+    uploadOptions: contractDeploymentOptions?.uploadOptions,
+    ERC725Account: {
+      version: erc725AccountVersion,
+      byteCode: erc725AccountBytecode,
+      libAddress: erc725AccountLibAddress,
+      deployProxy: contractDeploymentOptions?.ERC725Account?.deployProxy,
+    },
+    KeyManager: {
+      version: keyManagerVersion,
+      byteCode: keyManagerBytecode,
+      libAddress: keyManagerLibAddress,
+      deployProxy: contractDeploymentOptions?.KeyManager?.deployProxy,
+    },
+    UniversalReceiverDelegate: {
+      version: universalReceiverDelegateVersion,
+      byteCode: universalReceiverDelegateBytecode,
+      libAddress: universalReceiverDelegateLibAddress,
+      deployProxy: contractDeploymentOptions?.UniversalReceiverDelegate?.deployProxy,
+    },
+    deployReactive: contractDeploymentOptions?.deployReactive,
+  };
 }

--- a/test/test.utils.ts
+++ b/test/test.utils.ts
@@ -10,6 +10,7 @@ import { ContractDeploymentOptions, LSPFactory } from '../build/main/src';
 import { DeployedContracts } from '../src/lib/interfaces';
 import { getDeployedByteCode, getProxyByteCode } from '../src/lib/helpers/deployment.helper';
 import { providers } from 'ethers';
+import { getAddress } from 'ethers/lib/utils';
 
 export async function deployUniversalProfileContracts(signer: Signer, owner: string) {
   let nonceManager = new NonceManager(signer);
@@ -47,8 +48,7 @@ export async function testUPDeployment(
 
   for (const contractName of contractNames) {
     if (
-      contractDeploymentOptions[contractName]?.libAddress ||
-      contractDeploymentOptions[contractName]?.byteCode ||
+      contractDeploymentOptions[contractName]?.version?.startsWith('0x') ||
       contractDeploymentOptions[contractName]?.deployProxy === false
     ) {
       expect(deployedContracts[`${contractName}BaseContract`]).toBeUndefined();
@@ -58,8 +58,8 @@ export async function testUPDeployment(
   }
 
   if (
-    contractDeploymentOptions.UniversalReceiverDelegate?.deployProxy &&
-    !contractDeploymentOptions.UniversalReceiverDelegate.libAddress
+    contractDeploymentOptions?.UniversalReceiverDelegate?.deployProxy &&
+    !isAddress(contractDeploymentOptions?.UniversalReceiverDelegate.version)
   ) {
     expect(deployedContracts[`UniversalReceiverDelegateBaseContract`]).toBeDefined();
   } else {
@@ -67,6 +67,15 @@ export async function testUPDeployment(
   }
 
   return deployedContracts as DeployedContracts;
+}
+
+function isAddress(address: string) {
+  try {
+    getAddress(address);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function testSetData(upAddress: string, keyManagerAddress: string, signer: Signer) {


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Improvement

### What is the current behaviour (you can also link to an open issue here)?
Currently contract deployment options accept `byteCode`, `version` and `libAddress` as separate config params.

This PR refactors this config object so now `version` will provide the function for all 3 possibilities. This stops the question of e.g. _"what happens if I pass a lib address with custom bytecode"_. Only `byteCode`, `version` OR `libAddress` can now be passed.

No changes to internal logic. A configuration object using the old config schema is created from the new deployment options structure to be passed to internal deployment code. 

### Other information:
**This is a breaking change to the configuration object for all  `deploy` methods.**