### PR TITLE
chore!: Flatten upload options object

### DIFF
--- a/docs/classes/lsp3-universal-profile.md
+++ b/docs/classes/lsp3-universal-profile.md
@@ -159,7 +159,7 @@ await lspFactory.LSP3UniversalProfile.deploy(
   },
   {
     deployReactive: true,
-  }
+  },
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);
@@ -299,7 +299,7 @@ Deployment Complete
 ## uploadProfileData
 
 ```js
-LSP3UniversalProfile.uploadProfileData(profileData, uploadOptions?);
+LSP3UniversalProfile.uploadProfileData(profileData, options?);
 ```
 
 Uploads the [LSP3Profile](../../../standards/universal-profile/lsp3-universal-profile-metadata) data to the desired endpoint. The endpoint can be a `HTTPS` URL pointing to a public or private storage solution, an IPFS node, or a cluster.
@@ -308,10 +308,10 @@ Will upload and process passed images.
 
 #### Parameters
 
-| Name             | Type   | Description                                                           |
-| :--------------- | :----- | :-------------------------------------------------------------------- |
-| `profileData`    | Object | An object containing the profile data to upload.                      |
-| `uploadOptions?` | Object | An object containing special options used for uploading profile data. |
+| Name          | Type   | Description                                                   |
+| :------------ | :----- | :------------------------------------------------------------ |
+| `profileData` | Object | An object containing the profile data to upload.              |
+| `options?`    | Object | An object containing options used for uploading profile data. |
 
 #### Returns
 
@@ -346,6 +346,54 @@ await LSP3UniversalProfile.uploadProfileData({
     },
   ],
 });
+
+/**
+{
+  profile: {
+    LSP3Profile: {
+      name: 'My Universal Profile',
+      description: 'My cool Universal Profile',
+      tags: [Array],
+      links: [Array],
+      profileImage: [Array],
+      backgroundImage: [Array]
+    }
+  },
+  url: 'ipfs://QmS7NCnoXub7ju13HZuDzJpWqWq15Nev4CC18821qBNbkx'
+}
+*/
+```
+
+```javascript title="Uploading profile data using a custom IPFS gateway"
+await LSP3UniversalProfile.uploadProfileData(
+  {
+    name: 'My Universal Profile',
+    description: 'My cool Universal Profile',
+    tags: ['Fashion', 'Design'],
+    links: [{ title: 'My Website', url: 'www.my-website.com' }],
+    profileImage: [
+      {
+        width: 500,
+        height: 500,
+        hashFunction: 'keccak256(bytes)',
+        hash: '0xfdafad027ecfe57eb4ad047b938805d1dec209d6e9f960fc320d7b9b11cbed14',
+        url: 'ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp',
+      },
+    ],
+    backgroundImage: [
+      {
+        width: 500,
+        height: 500,
+        hashFunction: 'keccak256(bytes)',
+        hash: '0xfdafad027ecfe57eb4ad047b938805d1dec209d6e9f960fc320d7b9b11cbed14',
+        url: 'ipfs://QmPLqMFHxiUgYAom3Zg4SiwoxDaFcZpHXpCmiDzxrtjSGp',
+      },
+    ],
+  },
+  {
+    ipfsGateway: 'https://ipfs.infura.io',
+  },
+);
 
 /**
 {

--- a/docs/classes/lsp4-digital-asset-metadata.md
+++ b/docs/classes/lsp4-digital-asset-metadata.md
@@ -37,7 +37,7 @@ If `uploadOptions` are not specified in the function call, and the function is u
 
 | Name                 | Type   | Description                                                                       |
 | :------------------- | :----- | :-------------------------------------------------------------------------------- |
-| `ipfsClientOptions?` | Object | IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
+| `ipfsGateway?` | Object or String | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
 
 #### Returns
 
@@ -118,7 +118,7 @@ const lspFactory = new LSPFactory(provider, {
   deployKey: myDeployKey,
   chainId: myChainId,
   uploadOptions: {
-    ipfsClientOptions: {
+    ipfsGateway: {
       host: 'ipfs.infura.io',
       port: 5001,
       protocol: 'https',

--- a/docs/classes/lsp4-digital-asset-metadata.md
+++ b/docs/classes/lsp4-digital-asset-metadata.md
@@ -8,20 +8,20 @@ title: LSP4DigitalAssetMetadata
 ## uploadMetadata
 
 ```js
-LSP4DigitalAssetMetadata.uploadMetadata(lsp4Metadata, uploadOptions?);
+LSP4DigitalAssetMetadata.uploadMetadata(lsp4Metadata, options?);
 ```
 
 Uploads and processes passed assets and images, and uploads the [LSP4 Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md) to IPFS.
 The `uploadMetadata` function is available as a static or non-static function callable on the `LSPFactory` library instance.
 
-If `uploadOptions` are not specified in the function call, and the function is used on an `LSPFactory` instance, the specified options in `uploadOptions` that were passed to the LSPFactory during instantiation will be used.
+If `options` are not specified in the function call, and the function is used on an `LSPFactory` instance, the specified options in `options` that were passed to the LSPFactory during instantiation will be used.
 
 #### Parameters
 
-| Name             | Type   | Description                                            |
-| :--------------- | :----- | :----------------------------------------------------- |
-| `metaData`       | Object | The metadata to be uploaded.                           |
-| `uploadOptions?` | Object | The specification how the metadata should be uploaded. |
+| Name       | Type   | Description                                            |
+| :--------- | :----- | :----------------------------------------------------- |
+| `metaData` | Object | The metadata to be uploaded.                           |
+| `options?` | Object | The specification how the metadata should be uploaded. |
 
 #### Parameters of `metaData`
 
@@ -33,10 +33,10 @@ If `uploadOptions` are not specified in the function call, and the function is u
 | `images?`     | File, AssetBuffer, or AssetMetadata[&nbsp;]      | The images of the digital asset.    |
 | `assets?`     | File, AssetBuffer, or AssetMetadata[&nbsp;]      | The assets of the digital asset.    |
 
-#### Parameters of `uploadOptions?`
+#### Parameters of `options?`
 
-| Name                 | Type   | Description                                                                       |
-| :------------------- | :----- | :-------------------------------------------------------------------------------- |
+| Name           | Type             | Description                                                                                                 |
+| :------------- | :--------------- | :---------------------------------------------------------------------------------------------------------- |
 | `ipfsGateway?` | Object or String | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
 
 #### Returns
@@ -78,7 +78,7 @@ await LSP4DigitalAssetMetadata.uploadMetadata(
 
 #### Upload Custom LSP4 Metadata Example
 
-```javascript title="Uploading LSP4Metadata using custom uploadOptions"
+```javascript title="Uploading LSP4Metadata using custom upload options"
 await LSP4DigitalAssetMetadata.uploadMetadata(
   {
     description: 'Digital Asset',
@@ -88,12 +88,12 @@ await LSP4DigitalAssetMetadata.uploadMetadata(
     links: [{ title: 'Cool', url: 'cool.com' }],
   },
   {
-    ipfsUploadOptions: {
+    ipfsGateway: {
       host: 'ipfs.infura.io',
       port: 5001,
       protocol: 'https',
     },
-  }
+  },
 );
 /**
 {
@@ -113,18 +113,17 @@ await LSP4DigitalAssetMetadata.uploadMetadata(
 
 #### Upload Custom LSP4 Metadata with LSP Factory Example
 
-```javascript title="Uploading LSP4Metadata using uploadOptions passed when instantiating LSPFactory"
+```javascript title="Uploading LSP4Metadata using upload options passed when instantiating LSPFactory"
 const lspFactory = new LSPFactory(provider, {
   deployKey: myDeployKey,
   chainId: myChainId,
-  uploadOptions: {
-    ipfsGateway: {
-      host: 'ipfs.infura.io',
-      port: 5001,
-      protocol: 'https',
-    },
+  ipfsGateway: {
+    host: 'ipfs.infura.io',
+    port: 5001,
+    protocol: 'https',
   },
 });
+
 await lspFactory.LSP4DigitalAssetMetadata.uploadMetadata({
   description: 'Digital Asset',
   assets: [asset],

--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -45,18 +45,15 @@ The property `digitalAssetMetadata?` can be:
 
 #### Parameters of `contractDeploymentOptions?`
 
-| Name                 | Type    | Description                                                                                                          |
-| :------------------- | :------ | :------------------------------------------------------------------------------------------------------------------- |
-| `version?`           | string  | The contract version you want to deploy. Defaults to latest version of the [lsp-smart-contracts] library.            |
-| `byteCode?`          | string  | The creation + runtime bytecode of the contract to deploy.                                                           |
-| `libAddress?`        | string  | The address of a base contract to be used in deployment as implementation behind a proxy contract (e.g., [EIP1167]). |
-| `deployReactive?`    | boolean | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
-| `deployProxy?`       | boolean | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
-| `uploadOptions?`     | Object  | The Specification of how the metadata should be uploaded.                                                            |
-| `ipfsGateway?`       | Object or String | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
+| Name              | Type             | Description                                                                                                          |
+| :---------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------- |
+| `version?`        | string           | The contract version you want to deploy. Defaults to latest version of the [lsp-smart-contracts] library.            |
+| `deployReactive?` | boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
+| `deployProxy?`    | boolean          | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
+| `ipfsGateway?`    | Object or String | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally.          |
 
 :::info
-You can read more about the `contractDeploymentOptions?` specification on [its official page](../deployment/digital-asset.md).
+You can read more about the `contractDeploymentOptions?` specification on [its official page](../deployment/digital-asset.md)
 :::
 
 #### Returns

--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -53,7 +53,7 @@ The property `digitalAssetMetadata?` can be:
 | `deployReactive?`    | boolean | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
 | `deployProxy?`       | boolean | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
 | `uploadOptions?`     | Object  | The Specification of how the metadata should be uploaded.                                                            |
-| `ipfsClientOptions?` | Object  | The IPFS client options as defined by the [IPFS-HTTP-Client] used internally.                                        |
+| `ipfsGateway?`       | Object or String | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
 
 :::info
 You can read more about the `contractDeploymentOptions?` specification on [its official page](../deployment/digital-asset.md).

--- a/docs/classes/lsp8-identifiable-digital-asset.md
+++ b/docs/classes/lsp8-identifiable-digital-asset.md
@@ -94,7 +94,7 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
     symbol: 'TKN',
     controllerAddress: '0xb74a88C43BCf691bd7A851f6603cb1868f6fc147',
   },
-  { deployReactive: true },
+  { deployReactive: true }
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -382,8 +382,22 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
 You can specify how you want your profile metadata to be uploaded by passing the `ipfsGateway` inside the `options` object. Here you can set the IPFS gateway where you want the metadata to be uploaded.
 
 :::note
-The options object takes an `ipfsGateway` object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
+The procedure takes a URL string or an object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
 :::
+
+If a URL is passed and no port is specified, the standard 5001 port will be used.
+
+```javascript title="Passing ipfsGateway URL"
+lspFactory.LSP7DigitalAsset.deploy({...}, {
+  ipfsGateway: 'https://ipfs.infura.io:5001'
+})
+```
+
+```javascript title="Passing ipfsGateway URL string with port set"
+lspFactory.LSP7DigitalAsset.deploy({...}, {
+  ipfsGateway: 'https://ipfs.infura.io' // No port set. Port 5001 will be used
+})
+```
 
 ```javascript
 await lspFactory.LSP7DigitalAsset.deploy({...}, {
@@ -395,7 +409,7 @@ await lspFactory.LSP7DigitalAsset.deploy({...}, {
 });
 ```
 
-If the `ipfsGateway` object is provided, it will override the `ipfsGateway` object passed during the instantiation of the LSPFactory.
+If the `ipfsGateway` parameter is provided, it will override the `ipfsGateway` object passed during the instantiation of the LSPFactory for this function call only.
 
 ### Reactive Deployment
 

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -379,15 +379,15 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
 
 ### IPFS Upload Options
 
-You can specify how you want your profile metadata to be uploaded by passing the `ipfsClientOptions` inside the `options` object. Here you can set the IPFS gateway where you want the metadata to be uploaded.
+You can specify how you want your profile metadata to be uploaded by passing the `ipfsGateway` inside the `options` object. Here you can set the IPFS gateway where you want the metadata to be uploaded.
 
 :::note
-The options object takes an `ipfsClientOptions` object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
+The options object takes an `ipfsGateway` object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
 :::
 
 ```javascript
 await lspFactory.LSP7DigitalAsset.deploy({...}, {
-  ipfsClientOptions: {
+  ipfsGateway: {
     host: 'ipfs.infura.io',
     port: 5001,
     protocol: 'https',
@@ -395,7 +395,7 @@ await lspFactory.LSP7DigitalAsset.deploy({...}, {
 });
 ```
 
-If the `ipfsClientOptions` object is provided, it will override the `ipfsClientOptions` object passed during the instantiation of the LSPFactory.
+If the `ipfsGateway` object is provided, it will override the `ipfsGateway` object passed during the instantiation of the LSPFactory.
 
 ### Reactive Deployment
 

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -418,10 +418,24 @@ lspFactory.UniversalProfile.deploy({...}, {
 You can specify how you want your profile metadata to be uploaded while passing the options object. Here you can set the IPFS gateway where you want the profile's metadata to be uploaded.
 
 :::note
-The procedure takes an `ipfsGateway` object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
+The procedure takes a URL string or an object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
 :::
 
-```javascript
+If a URL is passed and no port is specified, the standard 5001 port will be used.
+
+```javascript title="Passing ipfsGateway URL"
+lspFactory.UniversalProfile.deploy({...}, {
+  ipfsGateway: 'https://ipfs.infura.io:5001'
+})
+```
+
+```javascript title="Passing ipfsGateway URL string with port set"
+lspFactory.UniversalProfile.deploy({...}, {
+  ipfsGateway: 'https://ipfs.infura.io' // No port set. Port 5001 will be used
+})
+```
+
+```javascript title="Passing ipfsGateway options as an object"
 lspFactory.UniversalProfile.deploy({...}, {
   ipfsGateway: {
     host: 'ipfs.infura.io',
@@ -431,7 +445,7 @@ lspFactory.UniversalProfile.deploy({...}, {
 })
 ```
 
-If the `ipfsGateway` object is provided, it will override the `ipfsGateway` object passed during the instantiation of the LSPFactory.
+If the `ipfsGateway` parameter is provided, it will override the `ipfsGateway` object passed during the instantiation of the LSPFactory for this function call only.
 
 ### Reactive Deployment
 

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -418,12 +418,12 @@ lspFactory.UniversalProfile.deploy({...}, {
 You can specify how you want your profile metadata to be uploaded while passing the options object. Here you can set the IPFS gateway where you want the profile's metadata to be uploaded.
 
 :::note
-The procedure takes an `ipfsClientOptions` object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
+The procedure takes an `ipfsGateway` object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the specified IPFS node.
 :::
 
 ```javascript
 lspFactory.UniversalProfile.deploy({...}, {
-  ipfsClientOptions: {
+  ipfsGateway: {
     host: 'ipfs.infura.io',
     port: 5001,
     protocol: 'https',
@@ -431,7 +431,7 @@ lspFactory.UniversalProfile.deploy({...}, {
 })
 ```
 
-If the `ipfsClientOptions` object is provided, it will override the `ipfsClientOptions` object passed during the instantiation of the LSPFactory.
+If the `ipfsGateway` object is provided, it will override the `ipfsGateway` object passed during the instantiation of the LSPFactory.
 
 ### Reactive Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,6 +110,44 @@ You can now continue using your UP address within the dApp:
 const myUPAddress = myContracts.ERC725Account.address;
 ```
 
+## Options
+
+When instantiating LSPFactory options can be passed to specify parameters such as `chainId` and `ipfsGateway`.
+
+```javascript title="Instantiating LSPFactory with custom options set"
+const lspFactory = new LSPFactory(provider, {
+  deployKey: '0x...',
+  chainId: 22,
+  ipfsGateway: 'https://ipfs.infura.io:5001',
+});
+```
+
+#### Deploy Key
+
+`deployKey` is the private key which should sign the transactions sent by LSPFactory. This account must have enough gas to carry out the transactions.
+
+If no value is set here, LSPFactory will attempt to sign transactions via a browser extension.
+
+#### Chain Id
+
+`chainId` is used to specify the network that LSPFactory is interacting with. This is used in the [versions file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json) to reference base contracts deployed on the network used for [proxy deployment](./getting-started.md#proxy-deployment). Defaults to 22.
+
+#### IPFS Gateway
+
+`ipfsGateway` is used to specify the IPFS node which should be interacted with for uploading and retrieving metadata. `ipfsGateway` can be either a URL string or an object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the IPFS node.
+
+```javascript title="Instantiating LSPFactory with custom ipfsGateway options set"
+const lspFactory = new LSPFactory(provider, {
+  deployKey: '0x...',
+  chainId: 22,
+  ipfsGateway: {
+    host: 'ipfs.infura.io',
+    port: 5001,
+    protocol: 'https',
+  },
+});
+```
+
 ## Proxy Deployment
 
 LSPFactory uses proxy deployment of smart contracts to maximise gas efficiency. This can be configured inside the `options` object when deploying [Universal Profiles](./deployment/universal-profile.md) or [Digital Assets](./deployment/digital-asset.md).
@@ -131,7 +169,6 @@ When using proxy deployment you can specify the base contract address by passing
 The LSPFactory uses [RxJS](https://rxjs.dev/) library to deploy contracts. This can be leveraged for certain front-end behaviors to give better feedback to users when they trigger a deployment from a user interface. For example, you may want to implement a loading bar to tell users how deployment is progressing or display details and addresses of the contracts as they are deployed.
 
 When deploying, pass the `deployReactive` flag inside the `options` object when deploying an LSP smart contract to receive an [RxJS](https://rxjs.dev/) `Observable`, which will emit events as your contract is deployed.
-
 
 ```typescript title="Reactive deployment of a Universal Profile"
 const observable = await lspFactory.UniversalProfile.deploy({...}, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { LSPFactory } from './lib/lsp-factory';
 export { LSP3UniversalProfile } from './lib/classes/lsp3-universal-profile';
+export { LSP4DigitalAssetMetadata } from './lib/classes/lsp4-digital-asset-metadata';
 export { LSP8IdentifiableDigitalAsset } from './lib/classes/lsp8-identifiable-digital-asset';
 export { LSP7DigitalAsset } from './lib/classes/lsp7-digital-asset';
 export * from './lib/interfaces';

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -28,7 +28,7 @@ import { lsp3ProfileJson } from './../../../test/lsp3-profile.mock';
 import { DeployedContracts, DeploymentEvent } from './../interfaces';
 import { ProxyDeployer } from './proxy-deployer';
 
-jest.setTimeout(120000);
+jest.setTimeout(60000);
 jest.useRealTimers();
 describe('LSP3UniversalProfile', () => {
   let signers: SignerWithAddress[];

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -89,9 +89,7 @@ describe('LSP3UniversalProfile', () => {
           lsp3Profile: lsp3ProfileJson.LSP3Profile,
         },
         {
-          uploadOptions: {
-            ipfsClientOptions: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
-          },
+          ipfsClientOptions: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
         }
       );
 

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -28,7 +28,7 @@ import { lsp3ProfileJson } from './../../../test/lsp3-profile.mock';
 import { DeployedContracts, DeploymentEvent } from './../interfaces';
 import { ProxyDeployer } from './proxy-deployer';
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 jest.useRealTimers();
 describe('LSP3UniversalProfile', () => {
   let signers: SignerWithAddress[];

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -76,36 +76,44 @@ describe('LSP3UniversalProfile', () => {
     });
   });
   describe('Deploying with LSP3Profile Metadata with specified IPFS client options', () => {
-    let signer;
-    let universalProfile;
-    let keyManager;
+    const allowedIPFSGatewayFormats = [
+      { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
+      'https://ipfs.infura.io:5001',
+      'https://ipfs.infura.io',
+    ];
 
-    beforeAll(async () => {
-      signer = signers[0];
+    allowedIPFSGatewayFormats.forEach((allowedGatewayFormat) => {
+      let signer;
+      let universalProfile;
+      let keyManager;
 
-      const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy(
-        {
-          controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-          lsp3Profile: lsp3ProfileJson.LSP3Profile,
-        },
-        {
-          ipfsGateway: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
-        }
-      );
+      beforeAll(async () => {
+        signer = signers[0];
 
-      universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
-      keyManager = KeyManager;
-    });
+        const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy(
+          {
+            controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
+            lsp3Profile: lsp3ProfileJson.LSP3Profile,
+          },
+          {
+            ipfsGateway: allowedGatewayFormat,
+          }
+        );
 
-    it('should deploy and set LSP3Profile data', async () => {
-      const ownerAddress = await universalProfile.owner();
-      expect(ownerAddress).toEqual(keyManager.address);
+        universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
+        keyManager = KeyManager;
+      });
 
-      const data = await universalProfile.getData([
-        '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-      ]);
+      it('should deploy and set LSP3Profile data', async () => {
+        const ownerAddress = await universalProfile.owner();
+        expect(ownerAddress).toEqual(keyManager.address);
 
-      expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+        const data = await universalProfile.getData([
+          '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+        ]);
+
+        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
+      });
     });
   });
 

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -89,7 +89,7 @@ describe('LSP3UniversalProfile', () => {
           lsp3Profile: lsp3ProfileJson.LSP3Profile,
         },
         {
-          ipfsClientOptions: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
+          ipfsGateway: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
         }
       );
 

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -247,7 +247,7 @@ export class LSP3UniversalProfile {
     if (uploadOptions.url) {
       // TODO: simple HTTP upload
     } else {
-      uploadResponse = await ipfsUpload(JSON.stringify(profile), uploadOptions.ipfsClientOptions);
+      uploadResponse = await ipfsUpload(JSON.stringify(profile), uploadOptions.ipfsGateway);
     }
 
     return {

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -247,7 +247,7 @@ export class LSP3UniversalProfile {
     if (uploadOptions.url) {
       // TODO: simple HTTP upload
     } else {
-      uploadResponse = await ipfsUpload(JSON.stringify(profile), uploadOptions.ipfsGateway);
+      uploadResponse = await ipfsUpload(JSON.stringify(profile), uploadOptions?.ipfsGateway);
     }
 
     return {

--- a/src/lib/classes/lsp4-digital-asset-metadata.ts
+++ b/src/lib/classes/lsp4-digital-asset-metadata.ts
@@ -44,10 +44,7 @@ export class LSP4DigitalAssetMetadata {
     if (uploadOptions.url) {
       // TODO: implement simple HTTP upload
     } else {
-      uploadResponse = await ipfsUpload(
-        JSON.stringify(lsp4Metadata),
-        uploadOptions.ipfsClientOptions
-      );
+      uploadResponse = await ipfsUpload(JSON.stringify(lsp4Metadata), uploadOptions.ipfsGateway);
     }
 
     return {

--- a/src/lib/classes/lsp4-digital-asset-metadata.ts
+++ b/src/lib/classes/lsp4-digital-asset-metadata.ts
@@ -44,7 +44,7 @@ export class LSP4DigitalAssetMetadata {
     if (uploadOptions.url) {
       // TODO: implement simple HTTP upload
     } else {
-      uploadResponse = await ipfsUpload(JSON.stringify(lsp4Metadata), uploadOptions.ipfsGateway);
+      uploadResponse = await ipfsUpload(JSON.stringify(lsp4Metadata), uploadOptions?.ipfsGateway);
     }
 
     return {

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -13,7 +13,7 @@ import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 import { lsp4DigitalAsset } from './../../../test/lsp4-digital-asset.mock';
 import { ProxyDeployer } from './proxy-deployer';
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 jest.useRealTimers();
 
 describe('LSP7DigitalAsset', () => {

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -13,7 +13,7 @@ import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 import { lsp4DigitalAsset } from './../../../test/lsp4-digital-asset.mock';
 import { ProxyDeployer } from './proxy-deployer';
 
-jest.setTimeout(60000);
+jest.setTimeout(30000);
 jest.useRealTimers();
 
 describe('LSP7DigitalAsset', () => {

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -13,7 +13,7 @@ import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 
 import { ProxyDeployer } from './proxy-deployer';
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 jest.useRealTimers();
 
 describe('LSP8IdentifiableDigitalAsset', () => {

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -13,7 +13,7 @@ import { ERC725_ACCOUNT_INTERRFACE, LSP4_KEYS } from '../helpers/config.helper';
 
 import { ProxyDeployer } from './proxy-deployer';
 
-jest.setTimeout(60000);
+jest.setTimeout(30000);
 jest.useRealTimers();
 
 describe('LSP8IdentifiableDigitalAsset', () => {

--- a/src/lib/helpers/config.helper.ts
+++ b/src/lib/helpers/config.helper.ts
@@ -4,14 +4,14 @@ import { Options } from 'ipfs-http-client';
 
 import { UploadOptions } from '../interfaces/profile-upload-options';
 
-const defaultIpfsClientOptions: Options = {
+const defaultIpfsGateway: Options = {
   host: 'api.ipfs.lukso.network',
   port: 443,
   protocol: 'https',
 };
 
 export const defaultUploadOptions: UploadOptions = {
-  ipfsClientOptions: defaultIpfsClientOptions,
+  ipfsGateway: defaultIpfsGateway,
 };
 
 export const ERC725_ACCOUNT_INTERRFACE = '0x63cb749b';

--- a/src/lib/helpers/uploader.helper.spec.ts
+++ b/src/lib/helpers/uploader.helper.spec.ts
@@ -11,7 +11,7 @@ import { imageUpload, ipfsUpload } from './uploader.helper';
 
 jest.mock('ipfs-http-client');
 jest.mock('browser-image-compression');
-jest.setTimeout(60000);
+jest.setTimeout(30000);
 
 const file = new File(['FileContents'], 'file-name');
 describe('uploader.helper.spec.ts', () => {

--- a/src/lib/helpers/uploader.helper.spec.ts
+++ b/src/lib/helpers/uploader.helper.spec.ts
@@ -116,7 +116,7 @@ describe('uploader.helper.spec.ts', () => {
         type: 'image/zip',
       }),
       {
-        ipfsGateway: 'https://ipfs.lukso.network/ipfs',
+        ipfsGateway: 'https://api.ipfs.lukso.network',
       }
     );
 

--- a/src/lib/helpers/uploader.helper.spec.ts
+++ b/src/lib/helpers/uploader.helper.spec.ts
@@ -41,7 +41,7 @@ describe('uploader.helper.spec.ts', () => {
             type: 'zip',
           }),
           {
-            ipfsClientOptions: {},
+            ipfsGateway: {},
           }
         )
       ).rejects.toThrowError("File type: 'zip' does not start with 'image/'");
@@ -49,14 +49,14 @@ describe('uploader.helper.spec.ts', () => {
 
     it('should pin files when using IPFS', async () => {
       const { file, addMock } = await mockDependencies();
-      await imageUpload(file, { ipfsClientOptions: {} });
+      await imageUpload(file, { ipfsGateway: {} });
 
       expect(addMock).toHaveBeenCalledWith(file, { pin: true });
     });
 
     it('should resize images', async () => {
       const { file, drawFileInCanvasSpy } = await mockDependencies();
-      await imageUpload(file, { ipfsClientOptions: {} });
+      await imageUpload(file, { ipfsGateway: {} });
 
       expect(imageCompression).toHaveBeenCalledTimes(5);
       expect(drawFileInCanvasSpy).toBeCalledTimes(5);
@@ -94,7 +94,29 @@ describe('uploader.helper.spec.ts', () => {
         type: 'image/zip',
       }),
       {
-        ipfsClientOptions: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
+        ipfsGateway: { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
+      }
+    );
+
+    expect(addMock).toHaveBeenCalled();
+
+    expect(result.length === 5);
+    expect(result[0]).toHaveProperty('width');
+    expect(result[0]).toHaveProperty('height');
+    expect(result[0]).toHaveProperty('hashFunction');
+    expect(result[0]).toHaveProperty('hash');
+    expect(result[0]).toHaveProperty('url');
+  });
+
+  it('should accept IPFS url', async () => {
+    const { addMock } = await mockDependencies();
+
+    const result = await imageUpload(
+      new File(['sdfasdf'], 'file-name', {
+        type: 'image/zip',
+      }),
+      {
+        ipfsGateway: 'https://ipfs.lukso.network/ipfs',
       }
     );
 

--- a/src/lib/helpers/uploader.helper.spec.ts
+++ b/src/lib/helpers/uploader.helper.spec.ts
@@ -11,7 +11,7 @@ import { imageUpload, ipfsUpload } from './uploader.helper';
 
 jest.mock('ipfs-http-client');
 jest.mock('browser-image-compression');
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 const file = new File(['FileContents'], 'file-name');
 describe('uploader.helper.spec.ts', () => {

--- a/src/lib/helpers/uploader.helper.ts
+++ b/src/lib/helpers/uploader.helper.ts
@@ -2,11 +2,11 @@ import imageCompression from 'browser-image-compression';
 import { keccak256 } from 'ethers/lib/utils';
 import { AddResult } from 'ipfs-core-types/src/root';
 import { ImportCandidate } from 'ipfs-core-types/src/utils';
-import { create, Options } from 'ipfs-http-client';
+import { create, IPFSHTTPClient } from 'ipfs-http-client';
 
 import { ImageBuffer, ImageMetadata } from '../interfaces';
 import { AssetBuffer, AssetMetadata } from '../interfaces/metadata';
-import { UploadOptions } from '../interfaces/profile-upload-options';
+import { IPFSGateway, UploadOptions } from '../interfaces/profile-upload-options';
 
 export const defaultSizes = [1800, 1024, 640, 320, 180];
 export async function imageUpload(
@@ -51,7 +51,7 @@ export async function imageUpload(
       if (uploadOptions.url) {
         // TODO: add simple HTTP upload
       } else {
-        uploadResponse = await ipfsUpload(imgToUpload, uploadOptions.ipfsClientOptions);
+        uploadResponse = await ipfsUpload(imgToUpload, uploadOptions.ipfsGateway);
       }
 
       return {
@@ -84,7 +84,7 @@ export async function assetUpload(
   if (uploadOptions.url) {
     // TODO: Simple HTTP upload
   } else {
-    ipfsResult = await ipfsUpload(fileBuffer, uploadOptions.ipfsClientOptions);
+    ipfsResult = await ipfsUpload(fileBuffer, uploadOptions.ipfsGateway);
   }
 
   return {
@@ -95,8 +95,18 @@ export async function assetUpload(
   };
 }
 
-export async function ipfsUpload(file: ImportCandidate, options: Options): Promise<AddResult> {
-  const ipfs = create(options);
+export async function ipfsUpload(
+  file: ImportCandidate,
+  ipfsGateway: IPFSGateway
+): Promise<AddResult> {
+  let ipfs: IPFSHTTPClient;
+
+  if (typeof ipfsGateway === 'string') {
+    ipfs = create({ url: ipfsGateway });
+  } else {
+    ipfs = create(ipfsGateway);
+  }
+
   return await ipfs.add(file, {
     pin: true,
   });
@@ -148,4 +158,27 @@ export function isMetadataEncoded(metdata: string): boolean {
   }
 
   return false;
+}
+
+export function formatIPFSUrl(ipfsGateway: IPFSGateway, ipfsHash: string) {
+  let ipfsUrl: string;
+
+  if (typeof ipfsGateway === 'string') {
+    const hasIPFSSuffix = ipfsGateway.endsWith('/ipfs') || ipfsGateway.endsWith('/ipfs/');
+
+    if (hasIPFSSuffix) {
+      ipfsUrl = ipfsGateway.endsWith('/')
+        ? `${ipfsGateway}${ipfsHash}`
+        : `${ipfsGateway}/${ipfsHash}`;
+    } else {
+      ipfsUrl = `${ipfsGateway}/ipfs/${ipfsHash}`;
+    }
+  } else {
+    const protocol = ipfsGateway.host ?? 'https';
+    const host = ipfsGateway.host ?? 'ipfs.lukso.network';
+
+    ipfsUrl = `${[protocol]}://${host}/ipfs/${ipfsHash}`;
+  }
+
+  return ipfsUrl;
 }

--- a/src/lib/helpers/uploader.helper.ts
+++ b/src/lib/helpers/uploader.helper.ts
@@ -51,7 +51,7 @@ export async function imageUpload(
       if (uploadOptions.url) {
         // TODO: add simple HTTP upload
       } else {
-        uploadResponse = await ipfsUpload(imgToUpload, uploadOptions.ipfsGateway);
+        uploadResponse = await ipfsUpload(imgToUpload, uploadOptions?.ipfsGateway);
       }
 
       return {
@@ -84,7 +84,7 @@ export async function assetUpload(
   if (uploadOptions.url) {
     // TODO: Simple HTTP upload
   } else {
-    ipfsResult = await ipfsUpload(fileBuffer, uploadOptions.ipfsGateway);
+    ipfsResult = await ipfsUpload(fileBuffer, uploadOptions?.ipfsGateway);
   }
 
   return {
@@ -102,7 +102,19 @@ export async function ipfsUpload(
   let ipfs: IPFSHTTPClient;
 
   if (typeof ipfsGateway === 'string') {
-    ipfs = create({ url: ipfsGateway });
+    const isPortProvided = ipfsGateway.split(':').length > 2;
+
+    let url: string;
+
+    if (ipfsGateway.endsWith('/')) {
+      url = isPortProvided
+        ? ipfsGateway
+        : `${ipfsGateway.slice(0, ipfsGateway.length - 1)}:${5001}`;
+    } else {
+      url = isPortProvided ? ipfsGateway : `${ipfsGateway}:${5001}`;
+    }
+
+    ipfs = create({ url });
   } else {
     ipfs = create(ipfsGateway);
   }
@@ -164,18 +176,12 @@ export function formatIPFSUrl(ipfsGateway: IPFSGateway, ipfsHash: string) {
   let ipfsUrl: string;
 
   if (typeof ipfsGateway === 'string') {
-    const hasIPFSSuffix = ipfsGateway.endsWith('/ipfs') || ipfsGateway.endsWith('/ipfs/');
-
-    if (hasIPFSSuffix) {
-      ipfsUrl = ipfsGateway.endsWith('/')
-        ? `${ipfsGateway}${ipfsHash}`
-        : `${ipfsGateway}/${ipfsHash}`;
-    } else {
-      ipfsUrl = `${ipfsGateway}/ipfs/${ipfsHash}`;
-    }
+    ipfsUrl = ipfsGateway.endsWith('/')
+      ? `${ipfsGateway}${ipfsHash}`
+      : `${ipfsGateway}/${ipfsHash}`;
   } else {
-    const protocol = ipfsGateway.host ?? 'https';
-    const host = ipfsGateway.host ?? 'ipfs.lukso.network';
+    const protocol = ipfsGateway?.host ?? 'https';
+    const host = ipfsGateway?.host ?? 'ipfs.lukso.network';
 
     ipfsUrl = `${[protocol]}://${host}/ipfs/${ipfsHash}`;
   }

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -1,3 +1,5 @@
+import { Options as IPFSClientOptions } from 'ipfs-http-client';
+
 import { LSP4MetadataBeforeUpload, LSP4MetadataForEncoding } from './lsp4-digital-asset';
 import { UploadOptions } from './profile-upload-options';
 
@@ -31,7 +33,7 @@ export interface DeployedLSP7DigitalAsset {
 interface ContractDeploymentOptionsBase {
   version?: string;
   deployProxy?: boolean;
-  uploadOptions?: UploadOptions;
+  ipfsClientOptions?: IPFSClientOptions;
 }
 export interface ContractDeploymentOptionsReactive extends ContractDeploymentOptionsBase {
   deployReactive: true;

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -1,7 +1,5 @@
-import { Options as IPFSClientOptions } from 'ipfs-http-client';
-
 import { LSP4MetadataBeforeUpload, LSP4MetadataForEncoding } from './lsp4-digital-asset';
-import { UploadOptions } from './profile-upload-options';
+import { IPFSGateway, UploadOptions } from './profile-upload-options';
 
 import { DeployedContract } from '.';
 
@@ -33,7 +31,7 @@ export interface DeployedLSP7DigitalAsset {
 interface ContractDeploymentOptionsBase {
   version?: string;
   deployProxy?: boolean;
-  ipfsClientOptions?: IPFSClientOptions;
+  ipfsGateway?: IPFSGateway;
 }
 export interface ContractDeploymentOptionsReactive extends ContractDeploymentOptionsBase {
   deployReactive: true;

--- a/src/lib/interfaces/lsp-factory-options.ts
+++ b/src/lib/interfaces/lsp-factory-options.ts
@@ -1,9 +1,8 @@
 import { providers, Signer } from 'ethers';
+import { Options as IPFSClientOptions } from 'ipfs-http-client';
 
 import { UploadOptions } from './profile-upload-options';
-/**
- * TDB
- */
+
 export interface LSPFactoryOptions {
   provider: providers.Web3Provider | providers.JsonRpcProvider;
   chainId: number;
@@ -11,8 +10,7 @@ export interface LSPFactoryOptions {
   uploadOptions: UploadOptions;
 }
 
-export interface SignerOptions {
-  deployKey: string;
-  chainId: number;
-  uploadOptions?: UploadOptions;
+export interface InstantiationOptions {
+  chainId?: number;
+  ipfsClientOptions?: IPFSClientOptions;
 }

--- a/src/lib/interfaces/lsp-factory-options.ts
+++ b/src/lib/interfaces/lsp-factory-options.ts
@@ -9,7 +9,8 @@ export interface LSPFactoryOptions {
   uploadOptions: UploadOptions;
 }
 
-export interface InstantiationOptions {
+export interface SignerOptions {
+  deployKey?: string | Signer;
   chainId?: number;
   ipfsGateway?: IPFSGateway;
 }

--- a/src/lib/interfaces/lsp-factory-options.ts
+++ b/src/lib/interfaces/lsp-factory-options.ts
@@ -1,7 +1,6 @@
 import { providers, Signer } from 'ethers';
-import { Options as IPFSClientOptions } from 'ipfs-http-client';
 
-import { UploadOptions } from './profile-upload-options';
+import { IPFSGateway, UploadOptions } from './profile-upload-options';
 
 export interface LSPFactoryOptions {
   provider: providers.Web3Provider | providers.JsonRpcProvider;
@@ -12,5 +11,5 @@ export interface LSPFactoryOptions {
 
 export interface InstantiationOptions {
   chainId?: number;
-  ipfsClientOptions?: IPFSClientOptions;
+  ipfsGateway?: IPFSGateway;
 }

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -1,3 +1,5 @@
+import { Options as IPFSClientOptions } from 'ipfs-http-client';
+
 import { DeployedContract } from '../..';
 
 import { ProfileDataBeforeUpload } from './lsp3-profile';
@@ -48,7 +50,7 @@ interface ContractOptions {
 
 interface ContractDeploymentOptionsBase {
   version?: string;
-  uploadOptions?: UploadOptions;
+  ipfsClientOptions?: IPFSClientOptions;
   ERC725Account?: ContractOptions;
   KeyManager?: ContractOptions;
   UniversalReceiverDelegate?: ContractOptions;

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -2,7 +2,7 @@ import { Options as IPFSClientOptions } from 'ipfs-http-client';
 
 import { DeployedContract } from '../..';
 
-import { ProfileDataBeforeUpload } from './lsp3-profile';
+import { LSP3ProfileDataForEncoding, ProfileDataBeforeUpload } from './lsp3-profile';
 import { UploadOptions } from './profile-upload-options';
 
 export enum ContractNames {
@@ -26,7 +26,7 @@ export interface ProfileDeploymentOptions {
     universalReceiverDelegate?: string;
     keyManager?: string;
   };
-  lsp3Profile?: ProfileDataBeforeUpload | string;
+  lsp3Profile?: ProfileDataBeforeUpload | LSP3ProfileDataForEncoding | string;
 }
 export interface DeployedContracts {
   ERC725Account?: DeployedContract;

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -1,9 +1,7 @@
-import { Options as IPFSClientOptions } from 'ipfs-http-client';
-
 import { DeployedContract } from '../..';
 
 import { LSP3ProfileDataForEncoding, ProfileDataBeforeUpload } from './lsp3-profile';
-import { UploadOptions } from './profile-upload-options';
+import { IPFSGateway, UploadOptions } from './profile-upload-options';
 
 export enum ContractNames {
   ERC725_Account = 'ERC725Account',
@@ -50,7 +48,7 @@ interface ContractOptions {
 
 interface ContractDeploymentOptionsBase {
   version?: string;
-  ipfsClientOptions?: IPFSClientOptions;
+  ipfsGateway?: IPFSGateway;
   ERC725Account?: ContractOptions;
   KeyManager?: ContractOptions;
   UniversalReceiverDelegate?: ContractOptions;

--- a/src/lib/interfaces/profile-upload-options.ts
+++ b/src/lib/interfaces/profile-upload-options.ts
@@ -3,13 +3,15 @@ import { Options } from 'ipfs-http-client';
 export interface UploadOptionsHTTP {
   url: string;
   port?: number;
-  ipfsClientOptions?: never;
+  ipfsGateway?: never;
 }
 
 export interface UploadOptionsIPFS {
   url?: never;
   port?: never;
-  ipfsClientOptions: Options;
+  ipfsGateway: IPFSGateway;
 }
+
+export type IPFSGateway = Options | string;
 
 export type UploadOptions = UploadOptionsHTTP | UploadOptionsIPFS;

--- a/src/lib/lsp-factory.ts
+++ b/src/lib/lsp-factory.ts
@@ -36,8 +36,6 @@ export class LSPFactory {
   ) {
     let signer: Signer;
     let provider: providers.Web3Provider | providers.JsonRpcProvider;
-    const ipfsClientOptions = options?.ipfsClientOptions;
-    const chainId = options?.chainId || 22;
 
     if (typeof rpcUrlOrProvider === 'string') {
       provider = new ethers.providers.JsonRpcProvider(rpcUrlOrProvider);
@@ -55,11 +53,14 @@ export class LSPFactory {
       signer = provider.getSigner();
     }
 
+    const chainId = options?.chainId || 22;
+    const ipfsGateway = options?.ipfsGateway;
+
     this.options = {
       signer,
       provider,
       chainId,
-      uploadOptions: ipfsClientOptions ? { ipfsClientOptions } : undefined,
+      uploadOptions: ipfsGateway ? { ipfsGateway } : undefined,
     };
 
     this.LSP3UniversalProfile = new LSP3UniversalProfile(this.options);

--- a/src/lib/lsp-factory.ts
+++ b/src/lib/lsp-factory.ts
@@ -6,7 +6,7 @@ import { LSP7DigitalAsset } from './classes/lsp7-digital-asset';
 import { LSP8IdentifiableDigitalAsset } from './classes/lsp8-identifiable-digital-asset';
 import { ProxyDeployer } from './classes/proxy-deployer';
 import { EthersExternalProvider, LSPFactoryOptions } from './interfaces';
-import { SignerOptions } from './interfaces/lsp-factory-options';
+import { InstantiationOptions } from './interfaces/lsp-factory-options';
 
 /**
  * Factory for creating UniversalProfiles and Digital Assets
@@ -19,10 +19,10 @@ export class LSPFactory {
   LSP8IdentifiableDigitalAsset: LSP8IdentifiableDigitalAsset;
   ProxyDeployer: ProxyDeployer;
   /**
-   * TBD
    *
    * @param {string | providers.Web3Provider | providers.JsonRpcProvider | EthersExternalProvider } rpcUrlOrProvider
-   * @param {string | Signer | SignerOptions} privateKeyOrSigner
+   * @param {string | Signer} privateKeyOrSigner
+   * @param { InstantiationOptions } options
    * @param {number} [chainId=22] Lukso Testnet - 22 (0x16)
    */
   constructor(
@@ -31,12 +31,13 @@ export class LSPFactory {
       | providers.Web3Provider
       | providers.JsonRpcProvider
       | EthersExternalProvider,
-    privateKeyOrSigner?: string | Signer | SignerOptions
+    privateKeyOrSigner?: string | Signer,
+    options?: InstantiationOptions
   ) {
     let signer: Signer;
     let provider: providers.Web3Provider | providers.JsonRpcProvider;
-    let chainId = 22;
-    let uploadOptions;
+    const ipfsClientOptions = options?.ipfsClientOptions;
+    const chainId = options?.chainId || 22;
 
     if (typeof rpcUrlOrProvider === 'string') {
       provider = new ethers.providers.JsonRpcProvider(rpcUrlOrProvider);
@@ -52,17 +53,13 @@ export class LSPFactory {
       signer = new ethers.Wallet(privateKeyOrSigner, provider);
     } else if (!privateKeyOrSigner) {
       signer = provider.getSigner();
-    } else {
-      signer = new ethers.Wallet(privateKeyOrSigner.deployKey, provider);
-      chainId = privateKeyOrSigner.chainId;
-      uploadOptions = privateKeyOrSigner.uploadOptions;
     }
 
     this.options = {
       signer,
       provider,
       chainId,
-      uploadOptions,
+      uploadOptions: ipfsClientOptions ? { ipfsClientOptions } : undefined,
     };
 
     this.LSP3UniversalProfile = new LSP3UniversalProfile(this.options);

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -35,7 +35,7 @@ import {
   waitForReceipt,
 } from '../helpers/deployment.helper';
 import { erc725EncodeData } from '../helpers/erc725.helper';
-import { isMetadataEncoded } from '../helpers/uploader.helper';
+import { formatIPFSUrl, isMetadataEncoded } from '../helpers/uploader.helper';
 import {
   DeploymentEvent$,
   DeploymentEventContract,
@@ -373,11 +373,7 @@ export async function getLSP4MetadataUrl(
     const isIPFSUrl = lsp4Metadata.startsWith('ipfs://');
 
     if (isIPFSUrl) {
-      // TODO: Handle simple HTTP upload
-      const protocol = uploadOptions.ipfsClientOptions.host ?? 'https';
-      const host = uploadOptions.ipfsClientOptions.host ?? 'ipfs.lukso.network';
-
-      lsp4JsonUrl = `${[protocol]}://${host}/ipfs/${lsp4Metadata.split('/').at(-1)}`;
+      lsp4JsonUrl = formatIPFSUrl(uploadOptions.ipfsGateway, lsp4Metadata.split('/').at(-1));
     }
 
     const ipfsResponse = await axios.get(lsp4JsonUrl);
@@ -620,8 +616,8 @@ export function convertDigitalAssetConfigurationObject(
 
   return {
     deployProxy: contractDeploymentOptions?.deployProxy,
-    uploadOptions: contractDeploymentOptions?.ipfsClientOptions
-      ? { ipfsClientOptions: contractDeploymentOptions?.ipfsClientOptions }
+    uploadOptions: contractDeploymentOptions?.ipfsGateway
+      ? { ipfsGateway: contractDeploymentOptions?.ipfsGateway }
       : undefined,
     deployReactive: contractDeploymentOptions?.deployReactive,
     version,

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -373,7 +373,7 @@ export async function getLSP4MetadataUrl(
     const isIPFSUrl = lsp4Metadata.startsWith('ipfs://');
 
     if (isIPFSUrl) {
-      lsp4JsonUrl = formatIPFSUrl(uploadOptions.ipfsGateway, lsp4Metadata.split('/').at(-1));
+      lsp4JsonUrl = formatIPFSUrl(uploadOptions?.ipfsGateway, lsp4Metadata.split('/').at(-1));
     }
 
     const ipfsResponse = await axios.get(lsp4JsonUrl);

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -620,7 +620,9 @@ export function convertDigitalAssetConfigurationObject(
 
   return {
     deployProxy: contractDeploymentOptions?.deployProxy,
-    uploadOptions: contractDeploymentOptions?.uploadOptions,
+    uploadOptions: contractDeploymentOptions?.ipfsClientOptions
+      ? { ipfsClientOptions: contractDeploymentOptions?.ipfsClientOptions }
+      : undefined,
     deployReactive: contractDeploymentOptions?.deployReactive,
     version,
     byteCode,

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -26,7 +26,7 @@ import {
   waitForReceipt,
 } from '../helpers/deployment.helper';
 import { erc725EncodeData } from '../helpers/erc725.helper';
-import { isMetadataEncoded } from '../helpers/uploader.helper';
+import { formatIPFSUrl, isMetadataEncoded } from '../helpers/uploader.helper';
 import {
   BaseContractAddresses,
   ContractDeploymentOptions,
@@ -224,11 +224,7 @@ export async function getLsp3ProfileDataUrl(
     const isIPFSUrl = lsp3Profile.startsWith('ipfs://');
 
     if (isIPFSUrl) {
-      // TODO: Handle simple HTTP upload
-      const protocol = uploadOptions.ipfsClientOptions.host ?? 'https';
-      const host = uploadOptions.ipfsClientOptions.host ?? 'ipfs.lukso.network';
-
-      lsp3JsonUrl = `${[protocol]}://${host}/ipfs/${lsp3Profile.split('/').at(-1)}`;
+      lsp3JsonUrl = formatIPFSUrl(uploadOptions.ipfsGateway, lsp3Profile.split('/').at(-1));
     }
 
     const ipfsResponse = await axios.get(lsp3JsonUrl);
@@ -511,8 +507,8 @@ export function convertUniversalProfileConfigurationObject(
 
   return {
     version: contractDeploymentOptions?.version,
-    uploadOptions: contractDeploymentOptions?.ipfsClientOptions
-      ? { ipfsClientOptions: contractDeploymentOptions?.ipfsClientOptions }
+    uploadOptions: contractDeploymentOptions?.ipfsGateway
+      ? { ipfsGateway: contractDeploymentOptions?.ipfsGateway }
       : undefined,
     ERC725Account: {
       version: erc725AccountVersion,

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -224,7 +224,7 @@ export async function getLsp3ProfileDataUrl(
     const isIPFSUrl = lsp3Profile.startsWith('ipfs://');
 
     if (isIPFSUrl) {
-      lsp3JsonUrl = formatIPFSUrl(uploadOptions.ipfsGateway, lsp3Profile.split('/').at(-1));
+      lsp3JsonUrl = formatIPFSUrl(uploadOptions?.ipfsGateway, lsp3Profile.split('/').at(-1));
     }
 
     const ipfsResponse = await axios.get(lsp3JsonUrl);

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -511,7 +511,9 @@ export function convertUniversalProfileConfigurationObject(
 
   return {
     version: contractDeploymentOptions?.version,
-    uploadOptions: contractDeploymentOptions?.uploadOptions,
+    uploadOptions: contractDeploymentOptions?.ipfsClientOptions
+      ? { ipfsClientOptions: contractDeploymentOptions?.ipfsClientOptions }
+      : undefined,
     ERC725Account: {
       version: erc725AccountVersion,
       byteCode: erc725AccountBytecode,


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Flattens `uploadOptions` parameters to just `ipfsGateway`

Before:
```javascript
await lspFactory.LSP7DigitalAsset.deploy({...}, {
  uploadOptions: {
    ipfsClientOptions: {
      host: 'ipfs.infura.io',
      port: 5001,
      protocol: 'https',
    }
  }
});
```

After: 
```javascript
await lspFactory.LSP7DigitalAsset.deploy({...}, {
  ipfsGateway: {
    host: 'ipfs.infura.io',
    port: 5001,
    protocol: 'https',
  }
});
```

ipfsGateway can also be passed as a string:
```javascript
await lspFactory.LSP7DigitalAsset.deploy({...}, {
  ipfsGateway: "https://ipfs.infura.io:5001"
});
```

```javascript
await lspFactory.LSP7DigitalAsset.deploy({...}, {
  ipfsGateway: "https://ipfs.infura.io"
});
```

If no port is provided, port will be set to 5001

See example at https://docs.lukso.tech/tools/lsp-factoryjs/deployment/universal-profile#ipfs-upload-options

The ipfsClientOptions object is passed directly to the IPFS client. The available options can be seen here https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#usage