### PR TITLE
improvement: batch setData and transferOwnership transactions

### DIFF
--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -1,5 +1,5 @@
 import { NonceManager } from '@ethersproject/experimental';
-import { concat, Observable } from 'rxjs';
+import { concat, merge, Observable } from 'rxjs';
 import { concatAll } from 'rxjs/operators';
 
 import contractVersions from '../../versions.json';
@@ -31,10 +31,9 @@ import { keyManagerDeployment$ } from '../services/key-manager.service';
 import {
   accountDeployment$,
   convertUniversalProfileConfigurationObject,
-  getTransferOwnershipTransaction$,
   isSignerUniversalProfile$,
   lsp3ProfileUpload$,
-  setDataTransaction$,
+  setDataAndTransferOwnershipTransactions$,
 } from './../services/lsp3-account.service';
 import { universalReceiverDelegateDeployment$ } from './../services/universal-receiver.service';
 
@@ -171,32 +170,23 @@ export class LSP3UniversalProfile {
       deploymentConfiguration?.UniversalReceiverDelegate?.byteCode
     );
 
-    // 4 > set permissions, profile and universal
-    const setData$ = setDataTransaction$(
+    // 4 set permissions, profile and universal receiver + transfer ownership to KeyManager
+    const setDataAndTransferOwnership$ = setDataAndTransferOwnershipTransactions$(
       this.signer,
       account$,
       universalReceiver$,
       profileDeploymentOptions.controllerAddresses,
       lsp3Profile$,
       signerIsUniversalProfile$,
-      defaultUniversalReceiverAddress
-    );
-
-    // 5 > transfersOwnership to KeyManager
-    const transferOwnership$ = getTransferOwnershipTransaction$(
-      this.signer,
-      account$,
       keyManager$,
-      signerIsUniversalProfile$
+      defaultUniversalReceiverAddress
     );
 
     const deployment$ = concat([
       baseContractDeployment$,
       account$,
-      universalReceiver$,
-      keyManager$,
-      setData$,
-      transferOwnership$,
+      merge(universalReceiver$, keyManager$),
+      setDataAndTransferOwnership$,
     ]).pipe(concatAll());
 
     if (deploymentConfiguration?.deployReactive)

--- a/src/lib/helpers/config.helper.ts
+++ b/src/lib/helpers/config.helper.ts
@@ -5,7 +5,7 @@ import { Options } from 'ipfs-http-client';
 import { UploadOptions } from '../interfaces/profile-upload-options';
 
 const defaultIpfsClientOptions: Options = {
-  host: 'api.ipfs.lukso.network',
+  host: 'api.2eff.lukso.dev',
   port: 443,
   protocol: 'https',
 };

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -376,7 +376,7 @@ export async function getLSP4MetadataUrl(
     if (isIPFSUrl) {
       // TODO: Handle simple HTTP upload
       const protocol = uploadOptions.ipfsClientOptions.host ?? 'https';
-      const host = uploadOptions.ipfsClientOptions.host ?? 'ipfs.lukso.network';
+      const host = uploadOptions.ipfsClientOptions.host ?? '2eff.lukso.dev';
 
       lsp4JsonUrl = `${[protocol]}://${host}/ipfs/${lsp4Metadata.split('/').at(-1)}`;
     }

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -3,10 +3,11 @@ import axios from 'axios';
 import { ContractFactory, ethers } from 'ethers';
 import {
   concat,
+  defaultIfEmpty,
   EMPTY,
   forkJoin,
   from,
-  merge,
+  mergeMap,
   Observable,
   of,
   shareReplay,
@@ -423,61 +424,150 @@ export function setMetadataAndTransferOwnership$(
   digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   contractName: string,
   isSignerUniversalProfile$: Observable<boolean>
-) {
-  const setDataTransaction$ =
+): Observable<DeploymentEventTransaction> {
+  const setDataParameters$ =
     digitalAssetDeploymentOptions?.creators?.length ||
     digitalAssetDeploymentOptions?.digitalAssetMetadata
-      ? setLSP4Metadata$(
-          signer,
+      ? prepareLSP4SetDataTransaction$(
           digitalAsset$,
           lsp4Metadata$,
           contractName,
           digitalAssetDeploymentOptions,
           isSignerUniversalProfile$
         )
-      : EMPTY;
+      : EMPTY.pipe(defaultIfEmpty({ keysToSet: null, valuesToSet: null }), shareReplay());
 
-  const transferOwnershipTransaction$ = transferOwnership$(
-    signer,
+  const digitalAssetContractAddress$ = digitalAssetAddress$(
     digitalAsset$,
-    digitalAssetDeploymentOptions,
-    contractName,
     isSignerUniversalProfile$
   );
 
-  const setDataAndTransferOwnershipTransactions$ = concat(
-    setDataTransaction$,
-    transferOwnershipTransaction$
+  const pendingTransactionArray$ = forkJoin([
+    setDataParameters$,
+    digitalAssetContractAddress$,
+  ]).pipe(
+    switchMap(([{ keysToSet, valuesToSet }, digitalAssetAddress]) => {
+      return sendSetDataAndTransferOwnershipTransactions(
+        signer,
+        digitalAssetAddress,
+        keysToSet,
+        valuesToSet,
+        digitalAssetDeploymentOptions.controllerAddress,
+        contractName
+      );
+    }),
+    shareReplay()
   );
 
-  const transferOwnershipReceipt$ = waitForReceipt<DeploymentEventTransaction>(
-    transferOwnershipTransaction$
+  const transactions$ = pendingTransactionArray$.pipe(
+    switchMap((transactions) => {
+      return from(transactions);
+    }),
+    mergeMap(async (transaction) => {
+      return {
+        type: transaction.type,
+        contractName: transaction.contractName,
+        functionName: transaction.functionName,
+        status: transaction.status,
+        transaction: await transaction.pendingTransaction,
+      } as DeploymentEventTransaction;
+    }),
+    shareReplay()
   );
-  const setDataReceipt$ = waitForReceipt<DeploymentEventTransaction>(setDataTransaction$);
 
-  return merge(
-    setDataAndTransferOwnershipTransactions$,
-    transferOwnershipReceipt$,
-    setDataReceipt$
+  const receipt$ = transactions$.pipe(
+    mergeMap(async (deploymentEvent) => {
+      return {
+        type: deploymentEvent.type,
+        contractName: deploymentEvent.contractName,
+        functionName: deploymentEvent.functionName,
+        status: DeploymentStatus.COMPLETE,
+        receipt: await deploymentEvent.transaction.wait(),
+      } as DeploymentEventTransaction;
+    }),
+    shareReplay()
   );
+
+  return concat(transactions$, receipt$);
 }
 
-export function setLSP4Metadata$(
+export async function sendSetDataAndTransferOwnershipTransactions(
   signer: Signer,
+  digitalAssetAddress: string,
+  keysToSet: string[],
+  valuesToSet: string[],
+  controllerAddress: string,
+  contractName: string
+) {
+  const digitalAsset = new LSP7Mintable__factory(signer).attach(digitalAssetAddress);
+
+  let setDataTransaction: Promise<ethers.ContractTransaction>;
+  let transferOwnershipTransaction: Promise<ethers.ContractTransaction>;
+
+  const signerAddress = await signer.getAddress();
+
+  const transactionsArray = [];
+
+  if (keysToSet && valuesToSet) {
+    const setDataEstimate = await digitalAsset.estimateGas.setData(keysToSet, valuesToSet, {
+      gasPrice: GAS_PRICE,
+    });
+
+    setDataTransaction = digitalAsset.setData(keysToSet, valuesToSet, {
+      gasLimit: setDataEstimate.add(GAS_BUFFER),
+      gasPrice: GAS_PRICE,
+    });
+
+    transactionsArray.push({
+      type: DeploymentType.TRANSACTION,
+      contractName,
+      functionName: 'setData',
+      status: DeploymentStatus.PENDING,
+      pendingTransaction: setDataTransaction,
+    });
+  }
+
+  if (signerAddress !== controllerAddress) {
+    const transferOwnershipEstimate = await digitalAsset.estimateGas.transferOwnership(
+      controllerAddress,
+      {
+        from: signerAddress,
+        gasPrice: GAS_PRICE,
+      }
+    );
+
+    transferOwnershipTransaction = digitalAsset.transferOwnership(controllerAddress, {
+      from: signerAddress,
+      gasPrice: GAS_PRICE,
+      gasLimit: transferOwnershipEstimate.add(GAS_BUFFER),
+    });
+
+    transactionsArray.push({
+      type: DeploymentType.TRANSACTION,
+      status: DeploymentStatus.PENDING,
+      contractName,
+      functionName: 'transferOwnership',
+      pendingTransaction: transferOwnershipTransaction,
+    });
+  }
+
+  return transactionsArray;
+}
+
+export function prepareLSP4SetDataTransaction$(
   digitalAsset$: Observable<DigitalAssetDeploymentEvent>,
   lsp4Metadata$: Observable<string | null>,
   contractName: string,
   digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   isSignerUniversalProfile$: Observable<boolean>
-): Observable<DeploymentEventTransaction> {
+) {
   return forkJoin([digitalAsset$, lsp4Metadata$, isSignerUniversalProfile$]).pipe(
     switchMap(([{ receipt: digitalAssetReceipt }, lsp4Metadata, isSignerUniversalProfile]) => {
       const digitalAssetAddress = isSignerUniversalProfile
         ? digitalAssetReceipt.contractAddress || digitalAssetReceipt.logs[0].address
         : digitalAssetReceipt.contractAddress || digitalAssetReceipt.to;
 
-      return setData(
-        signer,
+      return prepareSetDataTransaction(
         digitalAssetAddress,
         lsp4Metadata,
         digitalAssetDeploymentOptions,
@@ -488,15 +578,12 @@ export function setLSP4Metadata$(
   );
 }
 
-async function setData(
-  signer: Signer,
+async function prepareSetDataTransaction(
   digitalAssetAddress: string,
   lsp4Metadata: string,
   digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
   contractName: string
-): Promise<DeploymentEventTransaction> {
-  const digitalAsset = new LSP7Mintable__factory(signer).attach(digitalAssetAddress);
-
+) {
   const creators = digitalAssetDeploymentOptions?.creators ?? [];
 
   const creatorArrayIndexKeys: string[] = [];
@@ -520,8 +607,8 @@ async function setData(
     );
   });
 
-  const keysToSet = [];
-  const valuesToSet = [];
+  const keysToSet: string[] = [];
+  const valuesToSet: string[] = [];
 
   if (creators.length) {
     keysToSet.push(LSP4_KEYS.LSP4_CREATORS_ARRAY);
@@ -538,29 +625,16 @@ async function setData(
     valuesToSet.push(lsp4Metadata);
   }
 
-  const gasEstimate = await digitalAsset.estimateGas.setData(keysToSet, valuesToSet, {
-    gasPrice: GAS_PRICE,
-  });
-
-  const transaction = await digitalAsset.setData(keysToSet, valuesToSet, {
-    gasLimit: gasEstimate.add(GAS_BUFFER),
-    gasPrice: GAS_PRICE,
-  });
-
   return {
-    type: DeploymentType.TRANSACTION,
+    digitalAssetAddress,
     contractName,
-    functionName: 'setData',
-    status: DeploymentStatus.PENDING,
-    transaction,
+    keysToSet,
+    valuesToSet,
   };
 }
 
-export function transferOwnership$(
-  signer: Signer,
+export function digitalAssetAddress$(
   digitalAsset$: DeploymentEvent$,
-  digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
-  contractName: string,
   isSignerUniversalProfile$: Observable<boolean>
 ) {
   return forkJoin([digitalAsset$, isSignerUniversalProfile$]).pipe(
@@ -570,49 +644,10 @@ export function transferOwnership$(
           digitalAssetDeploymentReceipt.logs[0].address
         : digitalAssetDeploymentReceipt.contractAddress || digitalAssetDeploymentReceipt.to;
 
-      return transferOwnership(
-        signer,
-        digitalAssetAddress,
-        digitalAssetDeploymentOptions.controllerAddress,
-        contractName
-      );
+      return of(digitalAssetAddress);
     }),
     shareReplay()
   );
-}
-
-async function transferOwnership(
-  signer: Signer,
-  digitalAssetAddress: string,
-  controllerAddress: string,
-  contractName: string
-): Promise<DeploymentEventTransaction> {
-  try {
-    const signerAddress = await signer.getAddress();
-    const digitalAsset = new LSP7Mintable__factory(signer).attach(digitalAssetAddress);
-
-    const gasEstimate = await digitalAsset.estimateGas.transferOwnership(controllerAddress, {
-      from: signerAddress,
-      gasPrice: GAS_PRICE,
-    });
-
-    const transaction = await digitalAsset.transferOwnership(controllerAddress, {
-      from: signerAddress,
-      gasPrice: GAS_PRICE,
-      gasLimit: gasEstimate.add(GAS_BUFFER),
-    });
-
-    return {
-      type: DeploymentType.TRANSACTION,
-      status: DeploymentStatus.PENDING,
-      contractName,
-      functionName: 'transferOwnership',
-      transaction,
-    };
-  } catch (error) {
-    console.error('Error when transferring ownership');
-    throw error;
-  }
 }
 
 export function convertDigitalAssetConfigurationObject(

--- a/src/lib/services/lsp3-account.service.spec.ts
+++ b/src/lib/services/lsp3-account.service.spec.ts
@@ -9,7 +9,7 @@ import {
   PREFIX_PERMISSIONS,
 } from '../helpers/config.helper';
 
-import { setData } from './lsp3-account.service';
+import { prepareSetDataParameters } from './lsp3-account.service';
 
 jest.setTimeout(60000);
 jest.useRealTimers();
@@ -20,7 +20,7 @@ describe('LSP3Account Service', () => {
     signers = await ethers.getSigners();
   });
 
-  describe('setData', () => {
+  describe('prepareSetDataParameters', () => {
     let abiCoder;
     let universalProfile, universalReceiverDelegate;
 
@@ -34,24 +34,22 @@ describe('LSP3Account Service', () => {
     });
 
     it('should set one controller address', async () => {
-      const transaction = await setData(
-        signers[0],
+      const { keysToSet, valuesToSet, erc725AccountAddress } = await prepareSetDataParameters(
         universalProfile.address,
         universalReceiverDelegate.address,
         [signers[0].address]
       );
-      expect(transaction.functionName).toEqual('setData(bytes32[],bytes[])');
+
+      expect(universalProfile.address).toEqual(erc725AccountAddress);
 
       // AddressPermissions[] array length should be 1
-      const [totalPermissionsSet] = await universalProfile.getData([ADDRESS_PERMISSIONS_ARRAY_KEY]);
+      const totalPermissionsSet = valuesToSet[keysToSet.indexOf(ADDRESS_PERMISSIONS_ARRAY_KEY)];
       const expectedLength = abiCoder.encode(['uint256'], [1]);
       expect(totalPermissionsSet).toEqual(expectedLength);
 
       // controller address should have default permissions set
       const controllerPermissionsKey = PREFIX_PERMISSIONS + signers[0].address.substring(2);
-      const [controllerPermissionsValue] = await universalProfile.getData([
-        controllerPermissionsKey,
-      ]);
+      const controllerPermissionsValue = valuesToSet[keysToSet.indexOf(controllerPermissionsKey)];
       const expectedPermissions = ERC725.encodePermissions(DEFAULT_PERMISSIONS);
       expect(controllerPermissionsValue).toEqual(expectedPermissions);
 
@@ -61,7 +59,7 @@ describe('LSP3Account Service', () => {
       const rightSideKey = ethers.utils.hexZeroPad(hexIndex, 16);
       const addressPermissionArrayIndexKey = leftSideKey + rightSideKey.substring(2);
 
-      const [result] = await universalProfile.getData([addressPermissionArrayIndexKey]);
+      const result = valuesToSet[keysToSet.indexOf(addressPermissionArrayIndexKey)];
       const checkedsumResult = ethers.utils.getAddress(result);
       expect(checkedsumResult).toEqual(signers[0].address);
     });
@@ -69,16 +67,14 @@ describe('LSP3Account Service', () => {
     it('should set 2 x controller addresses', async () => {
       const controllerAddresses = [signers[0].address, signers[0].address];
 
-      const transaction = await setData(
-        signers[0],
+      const { keysToSet, valuesToSet } = await prepareSetDataParameters(
         universalProfile.address,
         universalReceiverDelegate.address,
         controllerAddresses
       );
-      expect(transaction.functionName).toEqual('setData(bytes32[],bytes[])');
 
       // AddressPermissions[] array length should be 2
-      const [totalPermissionsSet] = await universalProfile.getData([ADDRESS_PERMISSIONS_ARRAY_KEY]);
+      const totalPermissionsSet = valuesToSet[keysToSet.indexOf(ADDRESS_PERMISSIONS_ARRAY_KEY)];
       const expectedLength = abiCoder.encode(['uint256'], [controllerAddresses.length]);
       expect(totalPermissionsSet).toEqual(expectedLength);
 
@@ -87,9 +83,8 @@ describe('LSP3Account Service', () => {
 
         // controller address should have default permissions set
         const controllerPermissionsKey = PREFIX_PERMISSIONS + controllerAddress.substring(2);
-        const [controllerPermissionsValue] = await universalProfile.getData([
-          controllerPermissionsKey,
-        ]);
+        const controllerPermissionsValue = valuesToSet[keysToSet.indexOf(controllerPermissionsKey)];
+
         const expectedPermissions = ERC725.encodePermissions(DEFAULT_PERMISSIONS);
         expect(controllerPermissionsValue).toEqual(expectedPermissions);
 
@@ -99,7 +94,7 @@ describe('LSP3Account Service', () => {
         const rightSideKey = ethers.utils.hexZeroPad(hexIndex, 16);
         const addressPermissionArrayIndexKey = leftSideKey + rightSideKey.substring(2);
 
-        const [result] = await universalProfile.getData([addressPermissionArrayIndexKey]);
+        const result = valuesToSet[keysToSet.indexOf(addressPermissionArrayIndexKey)];
         const checkedsumResult = ethers.utils.getAddress(result);
         expect(checkedsumResult).toEqual(controllerAddress);
       }
@@ -107,16 +102,14 @@ describe('LSP3Account Service', () => {
     it('should set 10 x controller addresses', async () => {
       const controllerAddresses = signers.slice(0, 10).map((signer) => signer.address);
 
-      const transaction = await setData(
-        signers[0],
+      const { keysToSet, valuesToSet } = await prepareSetDataParameters(
         universalProfile.address,
         universalReceiverDelegate.address,
         controllerAddresses
       );
-      expect(transaction.functionName).toEqual('setData(bytes32[],bytes[])');
 
       // AddressPermissions[] array length should be 10
-      const [totalPermissionsSet] = await universalProfile.getData([ADDRESS_PERMISSIONS_ARRAY_KEY]);
+      const totalPermissionsSet = valuesToSet[keysToSet.indexOf(ADDRESS_PERMISSIONS_ARRAY_KEY)];
       const expectedLength = abiCoder.encode(['uint256'], [controllerAddresses.length]);
       expect(totalPermissionsSet).toEqual(expectedLength);
 
@@ -125,9 +118,8 @@ describe('LSP3Account Service', () => {
 
         // controller address should have default permissions set
         const controllerPermissionsKey = PREFIX_PERMISSIONS + controllerAddress.substring(2);
-        const [controllerPermissionsValue] = await universalProfile.getData([
-          controllerPermissionsKey,
-        ]);
+        const controllerPermissionsValue = valuesToSet[keysToSet.indexOf(controllerPermissionsKey)];
+
         const expectedPermissions = ERC725.encodePermissions(DEFAULT_PERMISSIONS);
         expect(controllerPermissionsValue).toEqual(expectedPermissions);
 
@@ -137,7 +129,7 @@ describe('LSP3Account Service', () => {
         const rightSideKey = ethers.utils.hexZeroPad(hexIndex, 16);
         const addressPermissionArrayIndexKey = leftSideKey + rightSideKey.substring(2);
 
-        const [result] = await universalProfile.getData([addressPermissionArrayIndexKey]);
+        const result = valuesToSet[keysToSet.indexOf(addressPermissionArrayIndexKey)];
         const checkedsumResult = ethers.utils.getAddress(result);
         expect(checkedsumResult).toEqual(controllerAddress);
       }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Improvement

Batches `setData` and `transferOwnership` transactions together for digital assets and universal profile deployment. 
No longer waits for `setData` transaction to be mined before sending `transferOwnership`.

sending `transferOwnership` transaction does wait for `setData` to be sent, so nonces are in the correct order to avoid permission errors


