### PR TITLE
docs: improve class spec docs

### DIFF
--- a/docs/classes/lsp3-universal-profile.md
+++ b/docs/classes/lsp3-universal-profile.md
@@ -8,10 +8,7 @@ title: LSP3UniversalProfile
 ## deploy
 
 ```javascript
-lspFactory.LSP3UniversalProfile.deploy(
-  profileDeploymentOptions,
-  contractDeploymentOptions?
-);
+lspFactory.LSP3UniversalProfile.deploy(profileProperties [, options]);
 ```
 
 Deploys and **configures** a [Universal Profile](../../../standards/universal-profile/introduction) to the blockchain. It will deploy the following contracts:
@@ -26,49 +23,49 @@ After, it will:
 - set the Key Manager as the owner of the LSP0 ERC725 Account, and
 - set all [LSP6 Permissions](../../../standards/universal-profile/lsp6-key-manager#-types-of-permissions) to the `controllerAddresses` except `DELEGATECALL`.
 
-By default the [LSP1 Universal Receiver Delegate](../../../standards/universal-profile/lsp1-universal-receiver-delegate) contract that is specified in the [versions file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json) will be attached to the Universal Profile. A custom Universal Receiver Delegate can be optionally deployed, by passing custom bytecode to the ContractDeploymentOptions object. You can read more about it in the[Universal Profile Configuration](../deployment/universal-profile#configuration).
+By default the [LSP1 Universal Receiver Delegate](../../../standards/universal-profile/lsp1-universal-receiver-delegate) contract that is specified in the [versions file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json) will be attached to the Universal Profile. A custom Universal Receiver Delegate can be optionally deployed, by passing custom bytecode to the [`options`](../deployment/universal-profile#deployment-configuration) object.
 
-#### Parameters
+:::info
+Read more about configuring Universal Profile smart contracts deployment [here](../deployment/universal-profile#deployment-configuration).
 
-| Name                         | Type   | Description                              |
-| :--------------------------- | :----- | :--------------------------------------- |
-| `profileDeploymentOptions`   | Object | The options used for profile deployment. |
-| `contractDeploymentOptions?` | Object | Specifies contract deployment details.   |
+:::
 
-#### Properties of `profileDeploymentOptions`
+### Parameters
 
-| Name                  | Type           | Description                                                                  |
-| :-------------------- | :------------- | :--------------------------------------------------------------------------- |
-| `controllerAddresses` | string[&nbsp;] | A list of accounts (public addresses) with [all permissions] on UP creation. |
-| `lsp3Profile?`        | Object         | If set, the created Universal Profile will be populated with these values.   |
+#### 1. `profileProperties` - Object
 
-#### Properties of `lsp3Profile?`
+Object containing profile properties set during Universal Profile deployment.
 
-| Name               | Type                                             | Description                                    |
-| :----------------- | :----------------------------------------------- | :--------------------------------------------- |
-| `name`             | string                                           | The name of the Universal Profile.             |
-| `description`      | string                                           | The description of the Universal Profile.      |
-| `profileImage?`    | File, ImageBuffer, or ImageMetadata[&nbsp;]      | The profile image of the Universal Profile.    |
-| `backgroundImage?` | File, ImageBuffer, or ImageMetadata[&nbsp;]      | The background image of the Universal Profile. |
-| `tags?`            | string[&nbsp;]                                   | The tags of the Universal Profile.             |
-| `links?`           | {&nbsp;title: string, url: string&nbsp;}[&nbsp;] | The links related to the Universal Profile.    |
+| Name                                                                             | Type             | Description                                                                                                                                                                                              |
+| :------------------------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`controllerAddresses`](../deployment/universal-profile#controller-addresses)    | Array            | A list of public addresses which will have all [LSP6 permissions](../../../standards/smart-contracts/lsp6-key-manager.md) except `DELEGATECALL` set on the Universal Profile contract during deployment. |
+| [`lsp3Profile`](../deployment/universal-profile#adding-lsp3-metadata) (optional) | String \| Object | [LSP3 Profile metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-UniversalProfile-Metadata.md) which will be uploaded and set during deployment.                                       |
+
+#### 2. `options` - Object (optional)
+
+Object which specifies how the [UniversalProfile](../../../standards/universal-profile/lsp0-erc725account.md), [KeyManager](../../../standards/universal-profile/lsp6-key-manager.md) and [UniversalReceiverDelegate](../../../standards/universal-profile/lsp1-universal-receiver-delegate.md) smart contracts will be deployed.
+
+| Name                                                                               | Type             | Description                                                                                                                                                                                     |
+| :--------------------------------------------------------------------------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERC725Account` (optional)                                                         | Object           | Generic contract configuration object. Specify [`version`](../deployment/universal-profile#contract-versions) and [`deployProxy`](../deployment/universal-profile#proxy-deployment) parameters. |
+| `KeyManager` (optional)                                                            | Object           | Generic contract configuration object. Specify [`version`](../deployment/universal-profile#contract-versions) and [`deployProxy`](../deployment/universal-profile#proxy-deployment) parameters. |
+| `UniversalReceiverDelegate` (optional)                                             | Object           | Generic contract configuration object. Specify [`version`](../deployment/universal-profile#contract-versions) and [`deployProxy`](../deployment/universal-profile#proxy-deployment) parameters. |
+| [`version`](../deployment/universal-profile#contract-versions) (optional)          | String           | Sets the global contract version. All contracts will be deployed with this version if set.                                                                                                      |
+| [`deployReactive`](../deployment/universal-profile#reactive-deployment) (optional) | Boolean          | Specify whether a Promise or Observable should be returned.                                                                                                                                     |
+| [`ipfsGateway`](../deployment/universal-profile#ipfs-upload-options) (optional)    | String \| Object | IPFS gateway url or an object containing IPFS gateway options.                                                                                                                                  |
 
 :::info Contract Deployment Details
-See the [configuration specification](../deployment/universal-profile#configuration) for more information about the `contractDeploymentOptions?` property.
+See the [configuration specification](../deployment/universal-profile#configuration) for more information about the `options` property.
 :::
 
-#### Returns
+### Returns
 
-| Name         | Type           | Description                                                                                                       |
-| :----------- | :------------- | :---------------------------------------------------------------------------------------------------------------- |
-| `Promise`    | <Object/>      | An object containing deployed contract details by default.                                                        |
-| `Observable` | RxJS <Object/> | An [RxJS Observable] object, if `deployReactive` flag is set to `true` in the `contractDeploymentOptions?` object |
+| Type                                              | Description                                                                                                                              |
+| :------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise`                                         | Resolves to an object containing deployed contract details. Default return value.                                                        |
+| [`Observable`](https://rxjs.dev/guide/observable) | An [RxJS Observable] object which emits events as contracts are deployed. Retutned if `deployProxy` is set to `true` in `options` object |
 
-:::note
-The Observable is an object containing deployment events.
-:::
-
-#### Universal Profile Deployment Example
+### Example
 
 ```javascript title="Deploying a Universal Profile"
 await lspFactory.LSP3UniversalProfile.deploy({
@@ -159,7 +156,7 @@ await lspFactory.LSP3UniversalProfile.deploy(
   },
   {
     deployReactive: true,
-  }
+  },
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);
@@ -298,28 +295,51 @@ Deployment Complete
 
 ## uploadProfileData
 
-```js
-LSP3UniversalProfile.uploadProfileData(profileData, options?);
+```javascript
+lspFactory.LSP3UniversalProfile.uploadProfileData(profileData [, options]);
 ```
 
-Uploads the [LSP3Profile](../../../standards/universal-profile/lsp3-universal-profile-metadata) data to the desired endpoint. The endpoint can be a `HTTPS` URL pointing to a public or private storage solution, an IPFS node, or a cluster.
+Processes and uploads the [LSP3Profile Metadata](../../../standards/universal-profile/lsp3-universal-profile-metadata) to IPFS. The IPFS gateway can be set inside the `options` object.
 
-Will upload and process passed images.
+Will resize and upload passed images.
 
-#### Parameters
+Available as a static or non-static method callable on the LSPFactory library instance.
 
-| Name          | Type   | Description                                                   |
-| :------------ | :----- | :------------------------------------------------------------ |
-| `profileData` | Object | An object containing the profile data to upload.              |
-| `options?`    | Object | An object containing options used for uploading profile data. |
+### Parameters
 
-#### Returns
+#### 1. `profileData` - Object
 
-| Name      | Type                          | Description                           |
-| :-------- | :---------------------------- | :------------------------------------ |
-| `Promise` | <LSP3ProfileDataForEncoding\> | Processed [LSP3] data and upload URL. |
+Object containing the [LSP3 Metadata](../../../standards/universal-profile/lsp3-universal-profile-metadata) fields which will be processed and uploaded to IPFS.
 
-#### Uploading Profile Data Example
+:::info
+[Read more about how LSP3 Metadata is processed here](../deployment/universal-profile#uploading-lsp3-metadata-to-ipfs).
+
+:::
+
+| Name              | Type          | Description                                                                                |
+| :---------------- | :------------ | :----------------------------------------------------------------------------------------- |
+| `name`            | String        | The name of the Universal Profile                                                          |
+| `description`     | String        | The description of the Universal Profile                                                   |
+| `profileImage`    | File \| Array | Javascript File object or an array of image metadata for different sizes of the same image |
+| `backgroundImage` | File \| Array | Javascript File object or an Array of image metadata for different sizes of the same image |
+| `links`           | Array         | An Array of Objects containing `title` and `url` parameters.                               |
+| `tags`            | Object        | An object containing the profile data to upload.                                           |
+
+#### 2. `options` - Object (optional)
+
+Object containing configuration details of how the metadata should be uploaded.
+
+| Name                                                                            | Type             | Description                                                                                                 |
+| :------------------------------------------------------------------------------ | :--------------- | :---------------------------------------------------------------------------------------------------------- |
+| [`ipfsGateway`](../deployment/universal-profile#ipfs-upload-options) (optional) | String \| Object | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
+
+### Returns
+
+| Type    | Description                                                                |
+| :------ | :------------------------------------------------------------------------- |
+| Promise | Resolves to an object containing the processed [LSP3] data and upload URL. |
+
+### Examples
 
 ```javascript title="Uploading profile data"
 await LSP3UniversalProfile.uploadProfileData({
@@ -392,7 +412,41 @@ await LSP3UniversalProfile.uploadProfileData(
   },
   {
     ipfsGateway: 'https://ipfs.infura.io',
-  }
+  },
+);
+
+/**
+{
+  profile: {
+    LSP3Profile: {
+      name: 'My Universal Profile',
+      description: 'My cool Universal Profile',
+      tags: [Array],
+      links: [Array],
+      profileImage: [Array],
+      backgroundImage: [Array]
+    }
+  },
+  url: 'ipfs://QmS7NCnoXub7ju13HZuDzJpWqWq15Nev4CC18821qBNbkx'
+}
+*/
+```
+
+```javascript title="Uploading profile data using a custom IPFS options"
+await LSP3UniversalProfile.uploadProfileData(
+  {
+    name: 'My Universal Profile',
+    description: 'My cool Universal Profile',
+    tags: ['Fashion', 'Design'],
+    links: [{ title: 'My Website', url: 'www.my-website.com' }],
+  },
+  {
+    ipfsGateway: {
+      host: 'ipfs.infura.io',
+      port: 5001,
+      protocol: 'https',
+    },
+  },
 );
 
 /**

--- a/docs/classes/lsp4-digital-asset-metadata.md
+++ b/docs/classes/lsp4-digital-asset-metadata.md
@@ -8,49 +8,45 @@ title: LSP4DigitalAssetMetadata
 ## uploadMetadata
 
 ```js
-LSP4DigitalAssetMetadata.uploadMetadata(lsp4Metadata, options?);
+LSP4DigitalAssetMetadata.uploadMetadata(lsp4Metadata [, options]);
 ```
 
 Uploads and processes passed assets and images, and uploads the [LSP4 Digital Asset Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md) to IPFS.
 The `uploadMetadata` function is available as a static or non-static function callable on the `LSPFactory` library instance.
 
-If `options` are not specified in the function call, and the function is used on an `LSPFactory` instance, the specified options in `options` that were passed to the LSPFactory during instantiation will be used.
+If `options` are not specified in the function call, and the function is used on an `LSPFactory` instance, the specified `options` that were passed to the LSPFactory during instantiation will be used.
 
-#### Parameters
+### Parameters
 
-| Name       | Type   | Description                                            |
-| :--------- | :----- | :----------------------------------------------------- |
-| `metaData` | Object | The metadata to be uploaded.                           |
-| `options?` | Object | The specification how the metadata should be uploaded. |
+#### 1. `metaData` - Object (optional)
 
-#### Parameters of `metaData`
+| Name                | Type          | Description                                                                                                                                          |
+| :------------------ | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `description`       | String        | A description of the digital asset.                                                                                                                  |
+| `links` (optional)  | Array         | An Array of Objects containing title and url parameters.                                                                                             |
+| `icon` (optional)   | File \| Array | The icon of the digital asset passed as a JavaScript File object or an Array of image metadata objects for different sizes of the same image.        |
+| `images` (optional) | Array         | An Array of images where each image element is a JavaScript File object or an Array of image metadata Objects for different sizes of the same image. |
+| `assets` (optional) | Array         | An Array of assets where each asset is a JavaScript File object or an asset metadata Object.                                                         |
 
-| Name          | Type                                             | Description                         |
-| :------------ | :----------------------------------------------- | :---------------------------------- |
-| `description` | string                                           | A description of the digital asset. |
-| `links?`      | {&nbsp;title: string, url: string&nbsp;}[&nbsp;] | The links of the digital asset.     |
-| `icon?`       | File, AssetBuffer, or AssetMetadata[&nbsp;]      | The icon of the digital asset.      |
-| `images?`     | File, AssetBuffer, or AssetMetadata[&nbsp;]      | The images of the digital asset.    |
-| `assets?`     | File, AssetBuffer, or AssetMetadata[&nbsp;]      | The assets of the digital asset.    |
+#### 2. `options` - Object (optional)
 
-#### Parameters of `options?`
-
-| Name           | Type             | Description                                                                                                 |
-| :------------- | :--------------- | :---------------------------------------------------------------------------------------------------------- |
-| `ipfsGateway?` | Object or String | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
+| Name                                                                        | Type             | Description                                                                                                 |
+| :-------------------------------------------------------------------------- | :--------------- | :---------------------------------------------------------------------------------------------------------- |
+| [`ipfsGateway`](../deployment/digital-asset#ipfs-upload-options) (optional) | String \| Object | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally. |
 
 #### Returns
 
-| Name      | Type                       | Description                               |
-| :-------- | :------------------------- | :---------------------------------------- |
-| `Promise` | <LSP4MetadataForEncoding\> | The processed [LSP4] data and upload URL. |
+| Type      | Description                               |
+| :-------- | :---------------------------------------- |
+| `Promise` | The processed [LSP4] data and upload URL. |
 
-#### Upload LSP4 Metadata Example
+### Example
 
 ```javascript title="Uploading LSP4Metadata"
 const image = new File();
 const icon = new File();
 const asset = new File();
+
 await LSP4DigitalAssetMetadata.uploadMetadata(
     {
         description: "Digital Asset",

--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -8,66 +8,53 @@ title: LSP7DigitalAsset
 ## deploy
 
 ```js
-lspFactory.LSP7DigitalAsset.deploy(
-  digitalAssetDeploymentOptions,
-  contractDeploymentOptions?
-);
+lspFactory.LSP7DigitalAsset.deploy(digitalAssetProperties [, options]);
 ```
 
 Deploys a mintable [LSP7 Digital Asset](../../../standards/nft-2.0/LSP7-Digital-Asset).
 
-#### Parameters
+### Parameters
 
-| Name                            | Type   | Description                                          |
-| :------------------------------ | :----- | :--------------------------------------------------- |
-| `digitalAssetDeploymentOptions` | Object | The [constructor parameters] used when deploying.    |
-| `contractDeploymentOptions?`    | Object | The Specification for [Contract Deployment Options]. |
+#### 1. `digitalAssetProperties` - Object
 
-#### Parameters of `digitalAssetDeploymentOptions`
+Specify properties to be set on the LSP7 Digital Asset during deployment.
 
-| Name                    | Type                               | Description                                                                         |
-| :---------------------- | :--------------------------------- | :---------------------------------------------------------------------------------- |
-| `name`                  | string                             | The name of the token.                                                              |
-| `symbol`                | string                             | The symbol of the token.                                                            |
-| `controllerAddress`     | string                             | The owner of the contract.                                                          |
-| `isNFT`                 | boolean                            | Specify if the token should be fungible by setting the [LSP7 decimals] value to 18. |
-| `digitalAssetMetadata?` | LSP4MetadataBeforeUpload or string | The [LSP4] metadata to be attached to the smart contract.                           |
-| `creators?`             | string[&nbsp;]                     | The [LSP4] metadata to be attached to the smart contract.                           |
+| Name                                                                                    | Type             | Description                                                                                                                                      |
+| :-------------------------------------------------------------------------------------- | :--------------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`name`](../deployment/digital-asset#digital-asset-properties)                          | String           | The name of the token. Passed to the LSP7 smart contract as a constructor parameter                                                              |
+| [`symbol`](../deployment/digital-asset#digital-asset-properties)                        | String           | The symbol of the token. Passed to the LSP7 smart contract as a constructor parameter                                                            |
+| [`controllerAddress`](../deployment/digital-asset#controller-address)                   | String           | The owner of the contract. Passed to the LSP7 smart contract constructor parameter                                                               |
+| [`isNFT`](../deployment/digital-asset#lsp7-nft-20)                                      | Boolean          | Specify if the token should be fungible by setting the [LSP7 decimals] value to 18. Passed to the LSP7 smart contract as a constructor parameter |
+| [`digitalAssetMetadata`](../deployment/digital-asset#digital-asset-metadata) (optional) | Object \| String | The [LSP4] metadata to be attached to the smart contract.                                                                                        |
+| [`creators`](../deployment/digital-asset#adding-lsp4-metadata) (optional)               | Array            | The [LSP4] metadata to be attached to the smart contract.                                                                                        |
 
-:::info
-The property `digitalAssetMetadata?` can be:
+#### 2. `options` - Object (optional)
 
-- an encoded hex string,
-- an IPFS URL, or
-- a metadata object as defined in [Uploading LSP4 Digital Asset Metadata].
-  The property `creators?` is used to set the [LSP4Creators[&nbsp;]](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md#lsp4creators) key on the contract.
-  :::
+Object which specifies how the LSP7 Digital Asset will be deployed
 
-#### Parameters of `contractDeploymentOptions?`
-
-| Name              | Type             | Description                                                                                                          |
-| :---------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------- |
-| `version?`        | string           | The contract version you want to deploy. Defaults to latest version of the [lsp-smart-contracts] library.            |
-| `deployReactive?` | boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
-| `deployProxy?`    | boolean          | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
-| `ipfsGateway?`    | Object or String | ipfsGateway URL string or IPFS Client Options as defined by the [ipfs-http-client library] used internally.          |
+| Name                                                                           | Type             | Description                                                                                                          |
+| :----------------------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------- |
+| [`version`](../deployment/digital-asset#version) (optional)                    | String           | The contract version you want to deploy. Defaults to latest version of the [lsp-smart-contracts] library.            |
+| [`deployReactive`](../deployment/digital-asset#reactive-deployment) (optional) | Boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
+| [`deployProxy`](../deployment/digital-asset#proxy-deployment) (optional)       | Boolean          | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
+| [`ipfsGateway`](../deployment/digital-asset#ipfs-upload-options) (optional)    | String \| Object | An IPFS gateway URL or an object containing IPFS configuration options.                                              |
 
 :::info
-You can read more about the `contractDeploymentOptions?` specification on [its official page](../deployment/digital-asset.md)
+You can read more about the `options` object specification on [its official page](../deployment/digital-asset.md#deployment-configuration)
 :::
 
-#### Returns
+### Returns
 
-| Name         | Type                                                           | Description                                                 |
-| :----------- | :------------------------------------------------------------- | :---------------------------------------------------------- |
-| `Promise`    | <DeployedLSP7DigitalAsset\>, or <DigitalAssetDeploymentEvent\> | An object containing deployed contract details.             |
-| `Observable` | RxJS <Object\>                                                 | An [RxJS Observable], if `deployReactive` is set to `true`. |
+| Type         | Description                                                                                  |
+| :----------- | :------------------------------------------------------------------------------------------- |
+| `Promise`    | Resolves to an object containing deployed contract details. Default return value.            |
+| `Observable` | An [RxJS Observable]. Returned if `deployReactive` is set to `true` inside `options` object. |
 
 :::info
-The `deployReactive` flag can be set in the `ContractDeploymentOptions` object, and returns an [RxJS Observable] of deployment events.
+The `deployReactive` flag can be set in the `options` object to return an [RxJS Observable] of deployment events.
 :::
 
-#### Deployment of LSP7 Digital Asset Example
+### Example
 
 ```javascript title="Deploying an LSP7 Digital Asset"
 await lspFactory.LSP7DigitalAsset.deploy({

--- a/docs/classes/lsp8-identifiable-digital-asset.md
+++ b/docs/classes/lsp8-identifiable-digital-asset.md
@@ -8,42 +8,52 @@ title: LSP8IdentifiableDigitalAsset
 ## deploy
 
 ```js
-lspFactory.LSP8IdentifiableDigitalAsset.deploy(
-  digitalAssetDeploymentOptions,
-  contractDeploymentOptions?);
+lspFactory.LSP8IdentifiableDigitalAsset.deploy(digitalAssetProperties [, options]);
 ```
 
 Deploys a mintable [LSP8 Identifiable Digital Asset](../../../standards/nft-2.0/LSP8-Identifiable-Digital-Asset).
 
-#### Parameters
+### Parameters
 
-| Name                            | Type   | Description                                          |
-| :------------------------------ | :----- | :--------------------------------------------------- |
-| `digitalAssetDeploymentOptions` | Object | The [constructor parameters] used when deploying.    |
-| `contractDeploymentOptions?`    | Object | The Specification for [Contract Deployment Options]. |
+#### 1. `digitalAssetProperties` - Object
 
-#### Parameters of `digitalAssetDeploymentOptions`
+Specify properties to be set on the LSP8 Digital Asset during deployment.
 
-| Name                    | Type                               | Description                                               |
-| :---------------------- | :--------------------------------- | :-------------------------------------------------------- |
-| `name`                  | string                             | The name of the token.                                    |
-| `symbol`                | string                             | The symbol of the token.                                  |
-| `controllerAddress`     | string                             | The owner of the contract.                                |
-| `digitalAssetMetadata?` | LSP4MetadataBeforeUpload or string | The [LSP4] metadata to be attached to the smart contract. |
-| `creators?`             | string[&nbsp;]                     | The [LSP4] metadata to be attached to the smart contract. |
+| Name                                                                                    | Type             | Description                                                                           |
+| :-------------------------------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------ |
+| [`name`](../deployment/digital-asset#digital-asset-properties)                          | String           | The name of the token. Passed to the LSP8 smart contract as a constructor parameter   |
+| [`symbol`](../deployment/digital-asset#digital-asset-properties)                        | String           | The symbol of the token. Passed to the LSP8 smart contract as a constructor parameter |
+| [`controllerAddress`](../deployment/digital-asset#controller-address)                   | String           | The owner of the contract. Passed to the LSP8 smart contract constructor parameter    |
+| [`digitalAssetMetadata`](../deployment/digital-asset#digital-asset-metadata) (optional) | Object \| String | The [LSP4] metadata to be attached to the smart contract.                             |
+| [`creators`](../deployment/digital-asset#adding-lsp4-metadata) (optional)               | Array            | The [LSP4] metadata to be attached to the smart contract.                             |
 
-#### Returns
+#### 2. `options` - Object (optional)
 
-| Name         | Type                                                           | Description                                                |
-| :----------- | :------------------------------------------------------------- | :--------------------------------------------------------- |
-| `Promise`    | <DeployedLSP8DigitalAsset\>, or <DigitalAssetDeploymentEvent\> | An object containing deployed contract details.            |
-| `Observable` | RxJS <Object\>                                                 | An [RxJS Observable], if `deployReactive` is set to `true` |
+Object which specifies how the LSP8 Digital Asset will be deployed
+
+| Name                                                                           | Type             | Description                                                                                                          |
+| :----------------------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------- |
+| [`version`](../deployment/digital-asset#version) (optional)                    | String           | The contract version you want to deploy. Defaults to latest version of the [lsp-smart-contracts] library.            |
+| [`deployReactive`](../deployment/digital-asset#reactive-deployment) (optional) | Boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
+| [`deployProxy`](../deployment/digital-asset#proxy-deployment) (optional)       | Boolean          | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
+| [`ipfsGateway`](../deployment/digital-asset#ipfs-upload-options) (optional)    | String \| Object | An IPFS gateway URL or an object containing IPFS configuration options.                                              |
 
 :::info
-The `deployReactive` flag can be set in the `ContractDeploymentOptions` object, and returns an [RxJS Observable] of deployment events.
+You can read more about the `options` object specification on [its official page](../deployment/digital-asset.md#deployment-configuration)
 :::
 
-#### Deployment of LSP8 Identifiable Digital Asset Example
+### Returns
+
+| Type         | Description                                                                                  |
+| :----------- | :------------------------------------------------------------------------------------------- |
+| `Promise`    | Resolves to an object containing deployed contract details. Default return value.            |
+| `Observable` | An [RxJS Observable]. Returned if `deployReactive` is set to `true` inside `options` object. |
+
+:::info
+The `deployReactive` flag can be set in the `options` object to return an [RxJS Observable] of deployment events.
+:::
+
+### Example
 
 ```javascript title="Deploying an LSP8 Identifiable Digital Asset"
 await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
@@ -186,6 +196,13 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
 */
 ```
 
-[lsp4]: https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md
 [contract deployment options]: ../deployment/digital-asset/#deployment-configuration
 [rxjs observable]: https://rxjs.dev/guide/observable
+[constructor parameters]: ../../../../../standards/smart-contracts/lsp7-digital-asset#constructor
+[contract deployment options]: ../deployment/digital-asset.md
+[lsp4]: https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md
+[uploading lsp4 digital asset metadata]: ./lsp4-digital-asset-metadata#uploadMetadata
+[lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts
+[eip1167]: https://eips.ethereum.org/EIPS/eip-1167
+[rxjs observable]: https://rxjs.dev/guide/observable
+[ipfs-http-client]: https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -26,7 +26,7 @@ After, it will:
 
 These smart contracts linked with some [LSP3 Universal Profile Metadata](../../../standards/universal-profile/lsp3-universal-profile-metadata) form a Universal Profile. The metadata is the 'face' of your profile and contains information such as your name, description, and profile image.
 
-## Profile Options
+## Profile Properties
 
 Inside the `profileProperties` object, you can set profile configuration options such as the controller addresses and LSP3 metadata.
 


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Improves function parameter specification pages in class pages. 

- Links to more specifics descriptions on Deployment pages
- Removes optional `?` syntax in favour of `[, options]` or `(optional)` highlighting

Before: 
<img width="847" alt="image" src="https://user-images.githubusercontent.com/54543428/169024422-53cb2f29-f461-4be0-b943-211425e1280f.png">


After: 
<img width="811" alt="image" src="https://user-images.githubusercontent.com/54543428/169024367-d5169c71-ab0b-4013-81cf-e7bf68413d26.png">

