### PR TITLE
ci: remove permissions from release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ jobs:
   release:
     name: 📦 Create GitHub release and publish to NPM
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Ensure main branch


### PR DESCRIPTION
Remove permissions from release CI to stop permission errors