### PR TITLE
improvement!: Add generic contract options object to digital asset options

### DIFF
--- a/docs/classes/lsp3-universal-profile.md
+++ b/docs/classes/lsp3-universal-profile.md
@@ -45,14 +45,14 @@ Object containing profile properties set during Universal Profile deployment.
 
 Object which specifies how the [UniversalProfile](../../../standards/universal-profile/lsp0-erc725account.md), [KeyManager](../../../standards/universal-profile/lsp6-key-manager.md) and [UniversalReceiverDelegate](../../../standards/universal-profile/lsp1-universal-receiver-delegate.md) smart contracts will be deployed.
 
-| Name                                                                               | Type             | Description                                                                                                                                                                                     |
-| :--------------------------------------------------------------------------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ERC725Account` (optional)                                                         | Object           | Generic contract configuration object. Specify [`version`](../deployment/universal-profile#contract-versions) and [`deployProxy`](../deployment/universal-profile#proxy-deployment) parameters. |
-| `KeyManager` (optional)                                                            | Object           | Generic contract configuration object. Specify [`version`](../deployment/universal-profile#contract-versions) and [`deployProxy`](../deployment/universal-profile#proxy-deployment) parameters. |
-| `UniversalReceiverDelegate` (optional)                                             | Object           | Generic contract configuration object. Specify [`version`](../deployment/universal-profile#contract-versions) and [`deployProxy`](../deployment/universal-profile#proxy-deployment) parameters. |
-| [`version`](../deployment/universal-profile#contract-versions) (optional)          | String           | Sets the global contract version. All contracts will be deployed with this version if set.                                                                                                      |
-| [`deployReactive`](../deployment/universal-profile#reactive-deployment) (optional) | Boolean          | Specify whether a Promise or Observable should be returned.                                                                                                                                     |
-| [`ipfsGateway`](../deployment/universal-profile#ipfs-upload-options) (optional)    | String \| Object | IPFS gateway url or an object containing IPFS gateway options.                                                                                                                                  |
+| Name                                                                               | Type             | Description                                                                                                                                                       |
+| :--------------------------------------------------------------------------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`ERC725Account`](../deployment/options.md) (optional)                             | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters. |
+| [`LSP6Keymanager`](../deployment/options.md) (optional)                            | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters. |
+| [`LSP1UniversalReceiverDelegate`](../deployment/options.md) (optional)             | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters. |
+| [`version`](../deployment/universal-profile#contract-versions) (optional)          | String           | Sets the global contract version. All contracts will be deployed with this version if set.                                                                        |
+| [`deployReactive`](../deployment/universal-profile#reactive-deployment) (optional) | Boolean          | Specify whether a Promise or Observable should be returned.                                                                                                       |
+| [`ipfsGateway`](../deployment/universal-profile#ipfs-upload-options) (optional)    | String \| Object | IPFS gateway url or an object containing IPFS gateway options.                                                                                                    |
 
 :::info Contract Deployment Details
 See the [configuration specification](../deployment/universal-profile#configuration) for more information about the `options` property.
@@ -156,7 +156,7 @@ await lspFactory.LSP3UniversalProfile.deploy(
   },
   {
     deployReactive: true,
-  }
+  },
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);
@@ -415,7 +415,7 @@ await LSP3UniversalProfile.uploadProfileData(
   },
   {
     ipfsGateway: 'https://ipfs.infura.io',
-  }
+  },
 );
 
 /**
@@ -449,7 +449,7 @@ await LSP3UniversalProfile.uploadProfileData(
       port: 5001,
       protocol: 'https',
     },
-  }
+  },
 );
 
 /**

--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -32,12 +32,11 @@ Specify properties to be set on the LSP7 Digital Asset during deployment.
 
 Object which specifies how the LSP7 Digital Asset will be deployed
 
-| Name                                                                           | Type             | Description                                                                                                          |
-| :----------------------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------- |
-| [`version`](../deployment/digital-asset#version) (optional)                    | String           | The contract version you want to deploy. Defaults to latest version of the [lsp-smart-contracts] library.            |
-| [`deployReactive`](../deployment/digital-asset#reactive-deployment) (optional) | Boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
-| [`deployProxy`](../deployment/digital-asset#proxy-deployment) (optional)       | Boolean          | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
-| [`ipfsGateway`](../deployment/digital-asset#ipfs-upload-options) (optional)    | String \| Object | An IPFS gateway URL or an object containing IPFS configuration options.                                              |
+| Name                                                                           | Type             | Description                                                                                                                                                  |
+| :----------------------------------------------------------------------------- | :--------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`LSP7DigitalAsset`](../deployment/options.md) (optional)                      | String           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#version) parameters. |
+| [`deployReactive`](../deployment/digital-asset#reactive-deployment) (optional) | Boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                                                            |
+| [`ipfsGateway`](../deployment/digital-asset#ipfs-upload-options) (optional)    | String \| Object | An IPFS gateway URL or an object containing IPFS configuration options.                                                                                      |
 
 :::info
 You can read more about the `options` object specification on [its official page](../deployment/digital-asset.md#deployment-configuration)

--- a/docs/classes/lsp8-identifiable-digital-asset.md
+++ b/docs/classes/lsp8-identifiable-digital-asset.md
@@ -31,12 +31,11 @@ Specify properties to be set on the LSP8 Digital Asset during deployment.
 
 Object which specifies how the LSP8 Digital Asset will be deployed
 
-| Name                                                                           | Type             | Description                                                                                                          |
-| :----------------------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------- |
-| [`version`](../deployment/digital-asset#version) (optional)                    | String           | The contract version you want to deploy. Defaults to latest version of the [lsp-smart-contracts] library.            |
-| [`deployReactive`](../deployment/digital-asset#reactive-deployment) (optional) | Boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                    |
-| [`deployProxy`](../deployment/digital-asset#proxy-deployment) (optional)       | Boolean          | Whether the contract should be deployed using a proxy contract implementation (e.g., [EIP1167]). Defaults to `true`. |
-| [`ipfsGateway`](../deployment/digital-asset#ipfs-upload-options) (optional)    | String \| Object | An IPFS gateway URL or an object containing IPFS configuration options.                                              |
+| Name                                                                           | Type             | Description                                                                                                                                                  |
+| :----------------------------------------------------------------------------- | :--------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`LSP8IdentifiableDigitalAsset`](../deployment/options.md) (optional)          | String           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#version) parameters. |
+| [`deployReactive`](../deployment/digital-asset#reactive-deployment) (optional) | Boolean          | Whether to return an [RxJS Observable] of deployment events. Defaults to `false`.                                                                            |
+| [`ipfsGateway`](../deployment/digital-asset#ipfs-upload-options) (optional)    | String \| Object | An IPFS gateway URL or an object containing IPFS configuration options.                                                                                      |
 
 :::info
 You can read more about the `options` object specification on [its official page](../deployment/digital-asset.md#deployment-configuration)
@@ -104,7 +103,7 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
     symbol: 'TKN',
     controllerAddress: '0xb74a88C43BCf691bd7A851f6603cb1868f6fc147',
   },
-  { deployReactive: true }
+  { deployReactive: true },
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -318,69 +318,40 @@ LSPFactory will create five resized versions of any passed images, with max size
 
 ## Deployment Configuration
 
-Developers can select a unique deployment configuration for their Digital Asset contract using the `options` parameter. This allows easy deployment of a specific version or implementation of a Digital Asset smart contract.
+Developers can select a unique deployment configuration for their Digital Asset contract using the `options` parameter. This allows easy deployment of a specific version or implementation of a Digital Asset smart contract by passing the [`version`](./options.md#version) parameter.
+
+Under the [version](./options.md#version) parameter developers can pass a [version number](./options.md#version), [custom bytecode](./options.md#deploying-custom-bytecode) or a [base contract address](./options.md#custom-base-contract-address) to be used during deployment. By setting the [`deployProxy`](./options.md#deploy-proxy) parameter developers can specify whether the contract should be deployed using proxy deployment.
+
+:::info
+Read more about configuring proxy deployment and contract versioning [here](../deployment/options.md).
+
+:::
+
+```js title="Passing LSP7DigitalAsset contract options"
+await lspFactory.LSP7DigitalAsset.deploy({...}, {
+    LSP7DigitalAsset: {
+        version: '0x...', // Custom bytecode
+        deployProy: false
+    },
+})
+```
+
+```js title="Passing LSP8IdentifiableDigitalAsset contract options"
+await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
+    LSP8IdentifiableDigitalAsset: {
+        version: '0x87cd003F9Ac7d6eBcd811f7b427c7dBF6f6ba132', // Custom base contract address
+        deployProy: true
+    },
+})
+```
 
 ### Proxy Deployment
 
-By passing the `deployProxy` parameter developers can determine whether their digital asset smart contract should be deployed as a **minimal proxy contract** based on [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) or an entire contract with a constructor.
+By passing the [`deployProxy`](./options.md#deploy-proxy) parameter developers can determine whether their digital asset smart contract should be deployed as a **minimal proxy contract** based on [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) or an entire contract with a constructor.
 
 :::info
 `deployProxy` defaults to `true` for both LSP7 and LSP8. If `deployProxy` is set to false, a full contract with a constructor will be deployed at the latest version.
 :::
-
-Read more about how proxy deployment is used in the LSPFactory [here](../getting-started.md#proxy-deployment).
-
-### Version
-
-Under the `version` parameter developers can pass a [version number](./digital-asset.md#contract-versions), [custom bytecode](./digital-asset.md#deploying-custom-bytecode) or a [base contract address](./digital-asset.md#custom-base-contract-address) to be used during deployment.
-
-```javascript title="Deploying an LSP7 Digital Asset at version 0.4.1"
-await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
-  version: '0.4.1',
-  deployProxy: true
-});
-```
-
-#### Custom Base Contract Address
-
-When using proxy deployment you can specify the base contract address by passing an address to the `version` parameter. This allows you to specify the contract implementation by using a custom base contract you have deployed. LSPFactory will then deploy a proxy contract which inherits its logic from the specified base contract address.
-
-Any base contract address that developers pass here must adhere to the relevant LSP contract standard it is being used for.
-
-Read more about proxy deployment [here](../getting-started.md#proxy-deployment).
-
-```javascript title="Deploying an LSP7 Digital Asset with a specific base contract address"
-await lspFactory.LSP7DigitalAsset.deploy({...}, {
-  version: '0x00b1d454Eb5d917253FD6cb4D5560dEC30b0960c',
-  deployProxy: true
-});
-```
-
-#### Contract Versions
-
-LSPFactory stores the addresses of different base contract versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). By specifying a `version` number, developers can specify which base contract implementation should be used during deployment.
-
-```javascript
-await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
-  version: '0.5.0',
-});
-```
-
-#### Deploying Custom Bytecode
-
-When deploying a Digital Asset, you can use your custom contract implementation by passing the compiled creation bytecode of a contract you have written as the `version` parameter.
-
-The passed bytecode can be the instantiation bytecode of a custom contract implementation you have written according to your use case. The implementation must meet the relevant LSP standard requirements.
-
-:::note
-Contracts deployed from custom bytecode will not use any proxy contract deployment.
-:::
-
-```javascript title="Deploying an LSP8 digital Asset from custom bytecode"
-await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
-  version: '0x...', // Creation bytecode to be deployed
-});
-```
 
 ### IPFS Upload Options
 

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -331,7 +331,7 @@ Read more about configuring proxy deployment and contract versioning [here](../d
 await lspFactory.LSP7DigitalAsset.deploy({...}, {
     LSP7DigitalAsset: {
         version: '0x...', // Custom bytecode
-        deployProy: false
+        deployProxy: false
     },
 })
 ```
@@ -340,7 +340,7 @@ await lspFactory.LSP7DigitalAsset.deploy({...}, {
 await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
     LSP8IdentifiableDigitalAsset: {
         version: '0x87cd003F9Ac7d6eBcd811f7b427c7dBF6f6ba132', // Custom base contract address
-        deployProy: true
+        deployProxy: true
     },
 })
 ```

--- a/docs/deployment/options.md
+++ b/docs/deployment/options.md
@@ -105,15 +105,15 @@ lspFactory.UniversalProfile.deploy({...}, {
 await lspFactory.UniversalProfile.deploy({...}, {
     ERC725Account: {
         version: '0.5.0',
-        deployProy: true
+        deployProxy: true
     },
     LSP6Keymanager: {
         version: '0x...', // Custom bytecode
-        deployProy: false
+        deployProxy: false
     },
     LSP1UniversalReceiverDelegate: {
         version: '0x87cd003F9Ac7d6eBcd811f7b427c7dBF6f6ba132', // Custom base contract address
-        deployProy: true
+        deployProxy: true
     },
 })
 ```
@@ -122,7 +122,7 @@ await lspFactory.UniversalProfile.deploy({...}, {
 await lspFactory.LSP7DigitalAsset.deploy({...}, {
     LSP7DigitalAsset: {
         version: '0x...', // Custom bytecode
-        deployProy: false
+        deployProxy: false
     },
 })
 ```
@@ -131,7 +131,7 @@ await lspFactory.LSP7DigitalAsset.deploy({...}, {
 await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
     LSP8IdentifiableDigitalAsset: {
         version: '0x87cd003F9Ac7d6eBcd811f7b427c7dBF6f6ba132', // Custom base contract address
-        deployProy: true
+        deployProxy: true
     },
 })
 ```

--- a/docs/deployment/options.md
+++ b/docs/deployment/options.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 3
+title: Options
+---
+
+# Contract Options Object
+
+When deploying a Universal Profile or Digital Asset, each smart contract can be individually configured by passing a contract configuration object to the options parameter of the `deploy` function.
+
+## Parameters
+
+| Name                                                  | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                    |
+| :---------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`version`](./options.md#version) (optional)          | String  | Sets which version of the smart contract should be deployed. Can be a [version number](./options.md#contract-versions), [base contract address](./options.md#custom-base-contract-address), or [custom bytecode](#deploying-custom-bytecode). Defaults to the latest version available in the [versions file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). |
+| [`deployProxy`](./options.md#deploy-proxy) (optional) | Boolean | Determines whether the contract will be deployed as a **minimal proxy contract** based on [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) or an entire contract with a constructor.                                                                                                                                                                                                         |
+
+### Version
+
+Under the `version` parameter developers can specify a [version number](./options#contract-versions), [custom bytecode](./options.md#deploying-custom-bytecode) or a [base contract address](./options.md#custom-base-contract-address) to be used for the deployment of the smart contract.
+
+#### Custom Base Contract Address
+
+When using [proxy deployment](./options.md#deploy-proxy) developers can pass an address to the `version` parameter to specify the base contract address which the proxy contract will inherit its logic from. The base contract can contain some custom logic according to a specific use case.
+
+LSPFactory will then deploy a proxy contract which inherits its logic from the specified base contract address.
+
+:::info
+Any base contract address that developers pass here must adhere to the relevant LSP contract standard it is being used for.
+
+:::
+
+Read more about proxy deployment [here](./options#deploy-proxy).
+
+```javascript title="Deploying an LSP7 Digital Asset using a specific base contract address"
+await lspFactory.LSP7DigitalAsset.deploy({...}, {
+    LSP7DigitalAsset: {
+        version: '0x00b1d454Eb5d917253FD6cb4D5560dEC30b0960c',
+        deployProxy: true
+    }
+});
+```
+
+#### Contract Versions
+
+LSPFactory stores the addresses of different base contract versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). By specifying a `version` number, developers can specify which base contract version should be used during deployment.
+
+```javascript
+await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
+    LSP7DigitalAsset: {
+        version: '0.5.0',
+        deployProxy: true
+    }
+});
+```
+
+#### Deploying Custom Bytecode
+
+Developers can deploy a custom contract implementation by passing some compiled creation bytecode to the `version` parameter.
+
+This can be the instantiation bytecode of a custom LSP standard implementation written according to a custom use case. The implementation must meet the relevant LSP standard requirements.
+
+:::note
+Contracts deployed from custom bytecode will not use any proxy contract deployment.
+:::
+
+```javascript title="Deploying an LSP8 digital Asset from custom bytecode"
+lspFactory.UniversalProfile.deploy({...}, {
+  LSP6KeyManager: {
+    version: '0x...',
+  },
+})
+```
+
+### Deploy Proxy
+
+LSPFactory uses proxy deployment of smart contracts to maximise gas efficiency. This can be configured by passing the `deployProxy` parameter to determine whether a contract should be deployed as a **minimal proxy contract** based on [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) or an entire contract with a constructor.
+
+A proxy contract is a lightweight contract that inherits its logic by referencing the address of a base contract already deployed on the blockchain. Inheriting allows cheaper deployment because the smart contract logic has already been deployed in the base contract.
+
+:::info
+LSPFactory stores base contract addresses for different versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json) and will use the latest available base contract version if no version is specified.
+:::
+
+When using proxy deployment, LSPFactory will check that there is some bytecode deployed at the base contract address before deploying. If none is found, a new base contract will be deployed and referenced in the proxy contract. This process is helpful when using LSPFactory on a local development network like Hardhat, where there will be no pre-deployed base contracts.
+
+When using proxy deployment developers can specify the base contract address by passing the [`version`](./options.md#version) parameter. This allows deploying a specific contract implementation by deploying a proxy contract which inherits its logic from a previously deployed custom base contract.
+
+`deployProxy` defaults to `true` for all contracts except `LSP1UniversalProfile` when deploying a Universal Profile ([read more](../deployment/universal-profile.md#universal-receiver-delegate-proxy-deployment)).
+
+:::info
+If `deployProxy` is set to `false`, the smart contract will be deployed from the current version of the [lsp-smart-contracts library](https://github.com/lukso-network/lsp-smart-contracts).
+:::
+
+```javascript title="Deploying a Universal Profile using a full ERC725Account contract with constructor"
+lspFactory.UniversalProfile.deploy({...}, {
+  ERC725Account: {
+    deployProxy: false,
+  },
+})
+```
+
+## Examples
+
+```js title="Passing Universal Profile contract options"
+await lspFactory.UniversalProfile.deploy({...}, {
+    ERC725Account: {
+        version: '0.5.0',
+        deployProy: true
+    },
+    LSP6Keymanager: {
+        version: '0x...', // Custom bytecode
+        deployProy: false
+    },
+    LSP1UniversalReceiverDelegate: {
+        version: '0x87cd003F9Ac7d6eBcd811f7b427c7dBF6f6ba132', // Custom base contract address
+        deployProy: true
+    },
+})
+```
+
+```js title="Passing LSP7DigitalAsset contract options"
+await lspFactory.LSP7DigitalAsset.deploy({...}, {
+    LSP7DigitalAsset: {
+        version: '0x...', // Custom bytecode
+        deployProy: false
+    },
+})
+```
+
+```js title="Passing LSP8IdentifiableDigitalAsset contract options"
+await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
+    LSP8IdentifiableDigitalAsset: {
+        version: '0x87cd003F9Ac7d6eBcd811f7b427c7dBF6f6ba132', // Custom base contract address
+        deployProy: true
+    },
+})
+```

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -284,7 +284,7 @@ await UniversalProfile.uploadMetaData(myLSP3MetaData);
 A Universal Profile is composed of three smart contracts. [LSP0 ERC725 Account](../../../standards/universal-profile/lsp0-erc725account), [LSP6 Key Manager](../../../standards/universal-profile/lsp6-key-manager), and [LSP1-UniversalReceiver](../../../standards/generic-standards/lsp1-universal-receiver.md).
 When deploying a Universal Profile, you can configure how these contracts should be deployed inside the `options` object.
 
-Under the [`version`](./options.md#version) key developers can pass a [version number](./options.md#version), [custom bytecode](./options.md#deploying-custom-bytecode) or a [base contract address](./options.md#custom-base-contract-address) to be used during deployment. By setting the [`deployProxy`](./options.md#deploy-proxy) parameter developers can specify whether the contract should be deployed using proxy deployment.
+Under the [`version`](./options.md#version) key, developers can pass a [version number](./options.md#version), [custom bytecode](./options.md#deploying-custom-bytecode) or a [base contract address](./options.md#custom-base-contract-address) to be used during deployment. By setting the [`deployProxy`](./options.md#deploy-proxy) parameter developers can specify whether the contract should be deployed using proxy deployment.
 
 :::info
 `deployProxy` defaults to true for `ERC725Account` and `KeyManager` and false for `UniversalReceiverDelegate`.

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -313,7 +313,7 @@ await lspFactory.UniversalProfile.deploy({...}, {
 
 The `UniversalReceiverDelegate` is a logic contract that writes to the Universal Profile when it receives some asset. This operation is not specific to any particular Universal Profile, so developers can use the same `UniversalReceiverDelegate` contract for multiple different Universal Profile deployments.
 
-By default, no Universal Receiver Delegate contract will be deployed. Instead LSPFactory will use the latest available version of the `UniversalReceiverDelegate` version stored in the [version file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). This address is used directly on the Universal Profile and is given the `SETDATA` LSP6 permission.
+By default, no Universal Receiver Delegate contract will be deployed. Instead LSPFactory will use the latest available version of the `UniversalReceiverDelegate` version stored in the [version file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). This address is used directly on the Universal Profile and is given the [`SETDATA` LSP6 permission](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager#permissions).
 
 Reusing the `UniversalReceiverDelegate` address means that no `UniversalReceiverDelegate` contract needs to be deployed when deploying a Universal Profile which further reduces the gas cost of Universal Profile deployment.
 

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -282,59 +282,38 @@ await UniversalProfile.uploadMetaData(myLSP3MetaData);
 ## Deployment Configuration
 
 A Universal Profile is composed of three smart contracts. [LSP0 ERC725 Account](../../../standards/universal-profile/lsp0-erc725account), [LSP6 Key Manager](../../../standards/universal-profile/lsp6-key-manager), and [LSP1-UniversalReceiver](../../../standards/generic-standards/lsp1-universal-receiver.md).
-When deploying a Universal Profile, you can configure how developers should deploy these contracts inside the `contractDeploymentOptions` object. Builders can configure each contract separately. The available options are the same for all contracts.
+When deploying a Universal Profile, you can configure how these contracts should be deployed inside the `options` object.
 
-Under the `version` key developers can pass a [version number](./universal-profile#contract-versions), [custom bytecode](./universal-profile#deploying-custom-bytecode) or a [base contract address](./universal-profile#using-a-custom-address) to be used during deployment.
+Under the [`version`](./options.md#version) key developers can pass a [version number](./options.md#version), [custom bytecode](./options.md#deploying-custom-bytecode) or a [base contract address](./options.md#custom-base-contract-address) to be used during deployment. By setting the [`deployProxy`](./options.md#deploy-proxy) parameter developers can specify whether the contract should be deployed using proxy deployment.
+
+:::info
+`deployProxy` defaults to true for `ERC725Account` and `KeyManager` and false for `UniversalReceiverDelegate`.
+Read more about configuring proxy deployment and contract versioning [here](../deployment/options.md)
+
+:::
 
 ```javascript
 await lspFactory.UniversalProfile.deploy({...}, {
   ERC725Account: {
     version: '0.4.1', // Version number
+    deployProxy: true
   },
   UniversalReceiverDelegate: {
-    version: '0x...' // Custom bytecode
+    version: '0x...', // Custom bytecode
+    deployProxy: false
   },
   KeyManager: {
-    version: '0x6c1F3Ed2F99054C88897e2f32187ef15c62dC560' // Base contract address
+    version: '0x6c1F3Ed2F99054C88897e2f32187ef15c62dC560', // Base contract address
+    deployProxy: true
   }
 })
 ```
-
-### Proxy Deployment
-
-Proxy deployment allows you to determine whether your contract should be deployed as a **minimal proxy contract** based on [EIP1167](https://eips.ethereum.org/EIPS/eip-1167) or an entire contract with a constructor.
-
-```javascript
-lspFactory.UniversalProfile.deploy({...}, {
-  ERC725Account: {
-    deployProxy: false,
-  },
-})
-```
-
-A proxy contract is a lightweight contract that inherits its logic by referencing the address of a contract already deployed on the blockchain. Inheriting allows cheaper deployment of Universal Profiles because only the proxy contract needs to be deployed.
-
-LSPFactory stores base contract addresses inside the [version file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json).
-
-:::info
-The function will use the latest available base contract version if no version is specified in the version parameter.
-LSPFactory stores base contract addresses for different versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json).
-:::
-
-:::info
-
-- The property `deployProxy` defaults to `true` for `ERC725Account` and `LSP6KeyManager`
-- The property `deployProxy` defaults to `false` for `UniversalReceiverDelegate`.
-
-:::
-
-When using proxy deployment, LSPFactory will check that there is some bytecode deployed at the base contract address before deploying. A new base contract will be deployed and referenced in the proxy contract if there is none. This process is helpful when using LSPFactory on a local development network like Hardhat, where there will be no pre-deployed base contracts.
 
 #### Universal Receiver Delegate Proxy Deployment
 
 The `UniversalReceiverDelegate` is a logic contract that writes to the Universal Profile when it receives some asset. This operation is not specific to any particular Universal Profile, so developers can use the same `UniversalReceiverDelegate` contract for multiple different Universal Profile deployments.
 
-By default, LSPFactory will use the latest available version of the `UniversalReceiverDelegate` version stored in the [version file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). This address is used directly on the Universal Profile and is given the `SETDATA` LSP6 permission.
+By default, no Universal Receiver Delegate contract will be deployed. Instead LSPFactory will use the latest available version of the `UniversalReceiverDelegate` version stored in the [version file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). This address is used directly on the Universal Profile and is given the `SETDATA` LSP6 permission.
 
 Reusing the `UniversalReceiverDelegate` address means that no `UniversalReceiverDelegate` contract needs to be deployed when deploying a Universal Profile which further reduces the gas cost of Universal Profile deployment.
 
@@ -349,22 +328,8 @@ lspFactory.UniversalProfile.deploy({...}, {
 })
 ```
 
-### Using a Custom Address
-
-When using proxy deployment you can specify the base contract address by passing the `version` parameter. This allows you to deploy a specific contract implementation by using a custom base contract you have deployed.
-
-Any base contract address that developers pass here must adhere to the relevant LSP contract standard it is being used for.
-
-```javascript title="Deploying a Universal Profile using a custom ERC725Account base contract implementation"
-lspFactory.UniversalProfile.deploy({...}, {
-    ERC725Account: {
-        version: '0x00b1d454Eb5d917253FD6cb4D5560dEC30b0960c',
-    },
-})
-```
-
 :::info
-The `UniversalReceiverDelegate` contract does not use proxy deployment by default. If an address is passed to the `UniversalReceiverDelegate` `version` parameter and `deployProxy` is not set to `true`, LSPFactory will set the provided address directly on the ERC725Account as the [LSP1UniversalReceiverDelegate key](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#lsp1universalreceiverdelegate) and given the `SETDATA` LSP6 permission. You can read more in the [section above](./universal-profile#universal-receiver-delegate-proxy-deployment).
+The `UniversalReceiverDelegate` contract does not use proxy deployment by default. If an address is passed to the `LSP1UniversalReceiverDelegate` `version` parameter and `deployProxy` is not set to `true`, LSPFactory will set the provided address directly on the ERC725Account as the [LSP1UniversalReceiverDelegate key](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#lsp1universalreceiverdelegate) and the `SETDATA` LSP6 permission.
 :::
 
 ```javascript title="Using a custom UniversalReceiverDelegate address"

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -329,7 +329,7 @@ lspFactory.UniversalProfile.deploy({...}, {
 ```
 
 :::info
-The `UniversalReceiverDelegate` contract does not use proxy deployment by default. If an address is passed to the `LSP1UniversalReceiverDelegate` `version` parameter and `deployProxy` is not set to `true`, LSPFactory will set the provided address directly on the ERC725Account as the [LSP1UniversalReceiverDelegate key](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#lsp1universalreceiverdelegate) and the `SETDATA` LSP6 permission.
+The `UniversalReceiverDelegate` contract does not use proxy deployment by default. If an address is passed to the `LSP1UniversalReceiverDelegate` `version` parameter and `deployProxy` is not set to `true`, LSPFactory will set the provided address directly on the ERC725Account as the [LSP1UniversalReceiverDelegate key](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#lsp1universalreceiverdelegate) and the [`SETDATA` LSP6 permission](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager#permissions).
 :::
 
 ```javascript title="Using a custom UniversalReceiverDelegate address"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,22 +148,6 @@ const lspFactory = new LSPFactory(provider, {
 });
 ```
 
-## Proxy Deployment
-
-LSPFactory uses proxy deployment of smart contracts to maximise gas efficiency. This can be configured inside the `options` object when deploying [Universal Profiles](./deployment/universal-profile.md) or [Digital Assets](./deployment/digital-asset.md).
-
-When using proxy deployment contracts will be deployed as a **minimal proxy contract** based on [EIP1167](https://eips.ethereum.org/EIPS/eip-1167). This is a lightweight contract that inherits its logic by referencing the address of a contract already deployed on the blockchain. Inheriting allows cheaper deployment of Universal Profiles and Digital Assets because only the proxy contract needs to be deployed.
-
-Base contract addresses for different networks are stored internally in the [version file](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json) to allow a specific version of an LSP smart contract to be used. If no version is specified, the most recent base contract version will be referenced by the proxy contract.
-
-:::info
-A specific contract version can be used by passing the `version` parameter in the `options` object when deploying. If no version is specified the latest base contract address will be used.
-:::
-
-LSPFactory will check that there is some bytecode deployed at the base contract address before deploying. If none is found, a new base contract will be deployed and referenced in the proxy contract. This process is helpful when using LSPFactory on a local development network like Hardhat where there will be no pre-deployed base contracts.
-
-When using proxy deployment you can specify the base contract address by passing the `version` parameter inside the `options` object. This allows you to deploy a specific contract implementation by using a custom base contract you have deployed.
-
 ## Reactive deployment
 
 The LSPFactory uses [RxJS](https://rxjs.dev/) library to deploy contracts. This can be leveraged for certain front-end behaviors to give better feedback to users when they trigger a deployment from a user interface. For example, you may want to implement a loading bar to tell users how deployment is progressing or display details and addresses of the contracts as they are deployed.

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -10,10 +10,10 @@ import {
   LSPFactoryOptions,
 } from '../interfaces';
 import {
-  ContractDeploymentOptionsNonReactive,
-  ContractDeploymentOptionsReactive,
   ContractNames,
   DeployedLSP7DigitalAsset,
+  LSP7ContractDeploymentOptionsNonReactive,
+  LSP7ContractDeploymentOptionsReactive,
   LSP7DigitalAssetDeploymentOptions,
 } from '../interfaces/digital-asset-deployment';
 import {
@@ -30,8 +30,8 @@ import {
 import { isSignerUniversalProfile$ } from '../services/lsp3-account.service';
 
 type LSP7ObservableOrPromise<
-  T extends ContractDeploymentOptionsReactive | ContractDeploymentOptionsNonReactive
-> = T extends ContractDeploymentOptionsReactive
+  T extends LSP7ContractDeploymentOptionsReactive | LSP7ContractDeploymentOptionsNonReactive
+> = T extends LSP7ContractDeploymentOptionsReactive
   ? Observable<DeploymentEventContract | DeploymentEventTransaction>
   : Promise<DeployedLSP7DigitalAsset>;
 
@@ -72,8 +72,8 @@ export class LSP7DigitalAsset {
    */
   deploy<
     T extends
-      | ContractDeploymentOptionsReactive
-      | ContractDeploymentOptionsNonReactive = ContractDeploymentOptionsNonReactive
+      | LSP7ContractDeploymentOptionsReactive
+      | LSP7ContractDeploymentOptionsNonReactive = LSP7ContractDeploymentOptionsNonReactive
   >(
     digitalAssetDeploymentOptions: LSP7DigitalAssetDeploymentOptions,
     contractDeploymentOptions: T = undefined

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -62,7 +62,9 @@ describe('LSP7DigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        version: baseContract.address,
+        LSP7DigitalAsset: {
+          version: baseContract.address,
+        },
       }
     );
 
@@ -89,7 +91,9 @@ describe('LSP7DigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        deployProxy: false,
+        LSP7DigitalAsset: {
+          deployProxy: false,
+        },
       }
     );
 
@@ -160,7 +164,9 @@ describe('LSP7DigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        version: passedBytecode,
+        LSP7DigitalAsset: {
+          version: passedBytecode,
+        },
       }
     );
 

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -10,11 +10,11 @@ import {
   LSPFactoryOptions,
 } from '../interfaces';
 import {
-  ContractDeploymentOptionsNonReactive,
-  ContractDeploymentOptionsReactive,
   ContractNames,
   DeployedLSP8IdentifiableDigitalAsset,
   DigitalAssetDeploymentOptions,
+  LSP8ContractDeploymentOptionsNonReactive,
+  LSP8ContractDeploymentOptionsReactive,
 } from '../interfaces/digital-asset-deployment';
 import {
   lsp8BaseContractDeployment$,
@@ -30,8 +30,8 @@ import {
 import { isSignerUniversalProfile$ } from '../services/lsp3-account.service';
 
 type LSP8ObservableOrPromise<
-  T extends ContractDeploymentOptionsReactive | ContractDeploymentOptionsNonReactive
-> = T extends ContractDeploymentOptionsReactive
+  T extends LSP8ContractDeploymentOptionsReactive | LSP8ContractDeploymentOptionsNonReactive
+> = T extends LSP8ContractDeploymentOptionsReactive
   ? Observable<DeploymentEventContract | DeploymentEventTransaction>
   : Promise<DeployedLSP8IdentifiableDigitalAsset>;
 
@@ -71,8 +71,8 @@ export class LSP8IdentifiableDigitalAsset {
    */
   deploy<
     T extends
-      | ContractDeploymentOptionsReactive
-      | ContractDeploymentOptionsNonReactive = ContractDeploymentOptionsNonReactive
+      | LSP8ContractDeploymentOptionsReactive
+      | LSP8ContractDeploymentOptionsNonReactive = LSP8ContractDeploymentOptionsNonReactive
   >(
     digitalAssetDeploymentOptions: DigitalAssetDeploymentOptions,
     contractDeploymentOptions?: T

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -60,7 +60,9 @@ describe('LSP8IdentifiableDigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        version: baseContract.address,
+        LSP8IdentifiableDigitalAsset: {
+          version: baseContract.address,
+        },
       }
     );
 
@@ -126,7 +128,9 @@ describe('LSP8IdentifiableDigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        deployProxy: false,
+        LSP8IdentifiableDigitalAsset: {
+          deployProxy: false,
+        },
       }
     );
 
@@ -193,7 +197,9 @@ describe('LSP8IdentifiableDigitalAsset', () => {
         symbol: 'TKN',
       },
       {
-        version: passedBytecode,
+        LSP8IdentifiableDigitalAsset: {
+          version: passedBytecode,
+        },
       }
     );
 

--- a/src/lib/interfaces/contract-options.ts
+++ b/src/lib/interfaces/contract-options.ts
@@ -1,18 +1,4 @@
-/**
- * TBD
- */
 export interface ContractOptions {
-  version?: string; // version of the pre-deployed code to use
-  libAddress?: {
-    // use a custom address where the code is deployed, overwrites 'version'
-    KeyManager: string;
-    ERC725Account: string;
-    UniversalReceiverDelegate: string;
-  };
-  byteCode?: {
-    // add your own custom bytecode, overwrites 'version' and 'libAddress'
-    KeyManager: string;
-    ERC725Account: string;
-    UniversalReceiverDelegate: string;
-  };
+  version?: string;
+  deployProxy?: boolean;
 }

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -1,7 +1,7 @@
 import { LSP4MetadataBeforeUpload, LSP4MetadataForEncoding } from './lsp4-digital-asset';
 import { IPFSGateway, UploadOptions } from './profile-upload-options';
 
-import { DeployedContract } from '.';
+import { ContractOptions, DeployedContract } from '.';
 
 export enum ContractNames {
   LSP7_DIGITAL_ASSET = 'LSP7DigitalAsset',
@@ -29,21 +29,45 @@ export interface DeployedLSP7DigitalAsset {
 }
 
 interface ContractDeploymentOptionsBase {
-  version?: string;
-  deployProxy?: boolean;
   ipfsGateway?: IPFSGateway;
 }
-export interface ContractDeploymentOptionsReactive extends ContractDeploymentOptionsBase {
+
+interface LSP7ContractDeploymentOptionsBase extends ContractDeploymentOptionsBase {
+  LSP7DigitalAsset?: ContractOptions;
+}
+
+export interface LSP7ContractDeploymentOptionsReactive extends LSP7ContractDeploymentOptionsBase {
   deployReactive: true;
 }
 
-export interface ContractDeploymentOptionsNonReactive extends ContractDeploymentOptionsBase {
+export interface LSP7ContractDeploymentOptionsNonReactive
+  extends LSP7ContractDeploymentOptionsBase {
   deployReactive?: false;
 }
 
+export type LSP7ContractDeploymentOptions =
+  | LSP7ContractDeploymentOptionsReactive
+  | LSP7ContractDeploymentOptionsNonReactive;
+
+interface LSP8ContractDeploymentOptionsBase extends ContractDeploymentOptionsBase {
+  LSP8IdentifiableDigitalAsset?: ContractOptions;
+}
+export interface LSP8ContractDeploymentOptionsReactive extends LSP8ContractDeploymentOptionsBase {
+  deployReactive: true;
+}
+
+export interface LSP8ContractDeploymentOptionsNonReactive
+  extends LSP8ContractDeploymentOptionsBase {
+  deployReactive?: false;
+}
+
+export type LSP8ContractDeploymentOptions =
+  | LSP8ContractDeploymentOptionsReactive
+  | LSP8ContractDeploymentOptionsNonReactive;
+
 export type ContractDeploymentOptions =
-  | ContractDeploymentOptionsReactive
-  | ContractDeploymentOptionsNonReactive;
+  | LSP7ContractDeploymentOptions
+  | LSP8ContractDeploymentOptions;
 
 export interface DigitalAssetConfiguration {
   version?: string;

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -1,4 +1,4 @@
-import { DeployedContract } from '../..';
+import { ContractOptions, DeployedContract } from '../..';
 
 import { LSP3ProfileDataForEncoding, ProfileDataBeforeUpload } from './lsp3-profile';
 import { IPFSGateway, UploadOptions } from './profile-upload-options';
@@ -39,11 +39,6 @@ export interface BaseContractAddresses {
   [ContractNames.ERC725_Account]?: string;
   [ContractNames.KEY_MANAGER]?: string;
   [ContractNames.UNIVERSAL_RECEIVER]?: string;
-}
-
-interface ContractOptions {
-  version?: string;
-  deployProxy?: boolean;
 }
 
 interface ContractDeploymentOptionsBase {

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -649,12 +649,22 @@ export function digitalAssetAddress$(
 export function convertDigitalAssetConfigurationObject(
   contractDeploymentOptions?: ContractDeploymentOptions
 ): DigitalAssetConfiguration {
-  const { version, byteCode, libAddress } = convertContractDeploymentOptionsVersion(
-    contractDeploymentOptions?.version
-  );
+  let providedVersion: string;
+  let providedDeployProxy: boolean;
+
+  if ('LSP7DigitalAsset' in contractDeploymentOptions) {
+    providedVersion = contractDeploymentOptions?.LSP7DigitalAsset?.version;
+    providedDeployProxy = contractDeploymentOptions?.LSP7DigitalAsset?.deployProxy;
+  } else if ('LSP8IdentifiableDigitalAsset' in contractDeploymentOptions) {
+    providedVersion = contractDeploymentOptions?.LSP8IdentifiableDigitalAsset?.version;
+    providedDeployProxy = contractDeploymentOptions?.LSP8IdentifiableDigitalAsset?.deployProxy;
+  }
+
+  const { version, byteCode, libAddress } =
+    convertContractDeploymentOptionsVersion(providedVersion);
 
   return {
-    deployProxy: contractDeploymentOptions?.deployProxy,
+    deployProxy: providedDeployProxy,
     uploadOptions: contractDeploymentOptions?.ipfsGateway
       ? { ipfsGateway: contractDeploymentOptions?.ipfsGateway }
       : undefined,


### PR DESCRIPTION
Changes Digital Asset options object to use same structure as Universal Profile options for generic contract options

Uses full contract names as keys (LSP7DigitalAsset, LSP8IdentifiabledigitalAsset)

Before
```js
  lspFactory.LSP7DigitalAsset.deploy(
    { ... },
    {
      version: '0.5.0',
      deployProxy: true,
      ipfsGateway: '...',
    }
  );
```

After:
```js
  lspFactory.LSP7DigitalAsset.deploy(
    { ... },
    {
      LSP7DigitalAsset: {
          version: '0.5.0',
          deployProxy: true,
      },
      ipfsGateway: '...',
    }
  );
```
