### PR TITLE
improvement!: rename universal profile contracts

### DIFF
--- a/docs/classes/lsp3-universal-profile.md
+++ b/docs/classes/lsp3-universal-profile.md
@@ -45,14 +45,15 @@ Object containing profile properties set during Universal Profile deployment.
 
 Object which specifies how the [UniversalProfile](../../../standards/universal-profile/lsp0-erc725account.md), [KeyManager](../../../standards/universal-profile/lsp6-key-manager.md) and [UniversalReceiverDelegate](../../../standards/universal-profile/lsp1-universal-receiver-delegate.md) smart contracts will be deployed.
 
-| Name                                                                               | Type             | Description                                                                                                                                                       |
-| :--------------------------------------------------------------------------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`ERC725Account`](../deployment/options.md) (optional)                             | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters. |
-| [`LSP6Keymanager`](../deployment/options.md) (optional)                            | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters. |
-| [`LSP1UniversalReceiverDelegate`](../deployment/options.md) (optional)             | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters. |
-| [`version`](../deployment/universal-profile#contract-versions) (optional)          | String           | Sets the global contract version. All contracts will be deployed with this version if set.                                                                        |
-| [`deployReactive`](../deployment/universal-profile#reactive-deployment) (optional) | Boolean          | Specify whether a Promise or Observable should be returned.                                                                                                       |
-| [`ipfsGateway`](../deployment/universal-profile#ipfs-upload-options) (optional)    | String \| Object | IPFS gateway url or an object containing IPFS gateway options.                                                                                                    |
+| Name                                                                               | Type             | Description                                                                                                                                                                                                   |
+| :--------------------------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`LSP0ERC725Account`](../deployment/options.md) (optional)                         | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters.                                             |
+| [`ERC725Account`](../deployment/options.md) (optional)                             | Object           | Generic contract configuration object. Can be used instead of `LSP0ERC725Account`. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters. |
+| [`LSP6Keymanager`](../deployment/options.md) (optional)                            | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters.                                             |
+| [`LSP1UniversalReceiverDelegate`](../deployment/options.md) (optional)             | Object           | Generic contract configuration object. Takes [`version`](../deployment/options.md#version) and [`deployProxy`](../deployment/options.md#deploy-proxy) parameters.                                             |
+| [`version`](../deployment/universal-profile#contract-versions) (optional)          | String           | Sets the global contract version. All contracts will be deployed with this version if set.                                                                                                                    |
+| [`deployReactive`](../deployment/universal-profile#reactive-deployment) (optional) | Boolean          | Specify whether a Promise or Observable should be returned.                                                                                                                                                   |
+| [`ipfsGateway`](../deployment/universal-profile#ipfs-upload-options) (optional)    | String \| Object | IPFS gateway url or an object containing IPFS gateway options.                                                                                                                                                |
 
 :::info Contract Deployment Details
 See the [configuration specification](../deployment/universal-profile#configuration) for more information about the `options` property.
@@ -80,7 +81,7 @@ await lspFactory.LSP3UniversalProfile.deploy({
 
 /**
 {
-  ERC725Account: {
+  LSP0ERC725Account: {
     address: '0xaEc61B848954e4d69B1283810df8A7fB9bA23BF2',
     receipt: {
       to: null,
@@ -101,7 +102,7 @@ await lspFactory.LSP3UniversalProfile.deploy({
       events: []
     }
   },
-  UniversalReceiverDelegate: {
+  LSP1UniversalReceiverDelegate: {
     address: '0xd92C7cA9c493aFC0DF51cE480ec7bB7DC8394549',
     receipt: {
       to: null,
@@ -122,7 +123,7 @@ await lspFactory.LSP3UniversalProfile.deploy({
       events: []
     }
   },
-  KeyManager: {
+  LSP6KeyManager: {
     address: '0xdbD3297B9bD80cA20cA75a644b1Fa903B05A2Fc3',
     receipt: {
       to: null,
@@ -156,7 +157,7 @@ await lspFactory.LSP3UniversalProfile.deploy(
   },
   {
     deployReactive: true,
-  },
+  }
 ).subscribe({
   next: (deploymentEvent) => {
     console.log(deploymentEvent);
@@ -172,33 +173,33 @@ await lspFactory.LSP3UniversalProfile.deploy(
 /**
 {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   status: 'PENDING',
   transaction: {
     ...
   }
-}
+},
 {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   status: 'COMPLETE',
   contractAddress: '0x805761959e7B94090fedD51776C63AB474a76A95',
   receipt: {
    ...
   }
-}
+},
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'initialize(address)',
   status: 'PENDING',
   transaction: {
    ...
   }
-}
+},
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'initialize(address)',
   status: 'COMPLETE',
   receipt: {
@@ -207,83 +208,83 @@ await lspFactory.LSP3UniversalProfile.deploy(
 }
 {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   status: 'PENDING',
   transaction: {
     ...
   }
-}
+},
 {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   status: 'COMPLETE',
   contractAddress: '0x04952ED68B5386Ff0a9891A10E2B1F204f98e209',
   receipt: {
     ...
   }
-}
+},
 {
   type: 'TRANSACTION',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   functionName: 'initialize(address)',
   status: 'PENDING',
   transaction: {
     ...
   }
-}
+},
 {
   type: 'TRANSACTION',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   functionName: 'initialize(address)',
   status: 'COMPLETE',
   receipt: {
     ...
   }
-}
+},
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'setData(bytes32[],bytes[])',
   status: 'PENDING',
   transaction: {
    ...
   }
-}
+},
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'setData(bytes32[],bytes[])',
   status: 'COMPLETE',
   receipt: {
    ...
   }
-}
+},
 {
   type: 'TRANSACTION',
   status: 'PENDING',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'transferOwnership(address)',
   transaction: {
     ...
   }
-}
+},
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'transferOwnership(address)',
   status: 'COMPLETE',
   receipt: {
     ...
   }
-}
+},
 {
-  ERC725Account: {
+  LSP0ERC725Account: {
     address: '0x805761959e7B94090fedD51776C63AB474a76A95',
     receipt: {
      ...
     },
   },
-  KeyManager: {
+  LSP6KeyManager: {
     address: '0x04952ED68B5386Ff0a9891A10E2B1F204f98e209',
     receipt: {
       ...
@@ -415,7 +416,7 @@ await LSP3UniversalProfile.uploadProfileData(
   },
   {
     ipfsGateway: 'https://ipfs.infura.io',
-  },
+  }
 );
 
 /**
@@ -449,7 +450,7 @@ await LSP3UniversalProfile.uploadProfileData(
       port: 5001,
       protocol: 'https',
     },
-  },
+  }
 );
 
 /**

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -398,7 +398,17 @@ const observable = lspFactory.LSP7DigitalAsset.deploy({...}, {
   deployReactive: true
 });
 
-observable.subscribe();
+observable.subscribe({
+  next: (deploymentEvent) => {
+    console.log(deploymentEvent);
+  },
+  error: (error) => {
+    console.error(error);
+  },
+  complete: () => {
+    console.log('Digital Asset deployment completed');
+  },
+});
 ```
 
 The following events will be emitted:
@@ -485,6 +495,7 @@ The following events will be emitted:
     },
   }
 }
+Digital Asset deployment completed
 ```
 
 #### LSP8 Deployment Events

--- a/docs/deployment/options.md
+++ b/docs/deployment/options.md
@@ -42,7 +42,7 @@ await lspFactory.LSP7DigitalAsset.deploy({...}, {
 
 #### Contract Versions
 
-LSPFactory stores the addresses of different base contract versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). By specifying a `version` number, developers can specify which base contract version should be used during deployment.
+LSPFactory stores the addresses of different base contract versions [internally](https://github.com/lukso-network/tools-lsp-factory/blob/main/src/versions.json). By specifying a `version` number, developers can specify which base contract version should be used during deployment. The version number reflects the package version of the [lsp-smart-contracts library](https://github.com/lukso-network/tools-lsp-factory/releases) used to deploy the base contract.
 
 ```javascript
 await lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -207,7 +207,7 @@ Javascript's `File` object is only available when using javascript in the browse
 <script/>
 ```
 
-LSPFactory will create five resized versions of the passed image, with max sizes of `1800x1800`, `1024x1024`, `640x640`, `320x320`, `180x180`. These resized images will be set inside the `LSP3Metadata` and attached to the `ERC725Account`.
+LSPFactory will create five resized versions of the passed image, with max sizes of `1800x1800`, `1024x1024`, `640x640`, `320x320`, `180x180`. These resized images will be set inside the `LSP3Metadata` and attached to the `ERC725Account` contract.
 
 <!-- #### Using Image Buffers
 
@@ -294,15 +294,15 @@ Read more about configuring proxy deployment and contract versioning [here](../d
 
 ```javascript
 await lspFactory.UniversalProfile.deploy({...}, {
-  ERC725Account: {
+  LSP0ERC725Account: {
     version: '0.4.1', // Version number
     deployProxy: true
   },
-  UniversalReceiverDelegate: {
+  LSP1UniversalReceiverDelegate: {
     version: '0x...', // Custom bytecode
     deployProxy: false
   },
-  KeyManager: {
+  LSP6KeyManager: {
     version: '0x6c1F3Ed2F99054C88897e2f32187ef15c62dC560', // Base contract address
     deployProxy: true
   }
@@ -321,7 +321,7 @@ To specify that your `UniversalReceiverDelegate` contract should use proxy deplo
 
 ```javascript
 lspFactory.UniversalProfile.deploy({...}, {
-    UniversalReceiverDelegate: {
+    LSP1UniversalReceiverDelegate: {
         deployProxy: true,
         version: '0x00b1d454Eb5d917253FD6cb4D5560dEC30b0960c',
     },
@@ -334,7 +334,7 @@ The `UniversalReceiverDelegate` contract does not use proxy deployment by defaul
 
 ```javascript title="Using a custom UniversalReceiverDelegate address"
 lspFactory.UniversalProfile.deploy({...}, {
-    UniversalReceiverDelegate: {
+    LSP1UniversalReceiverDelegate: {
         version: '0x00b1d454Eb5d917253FD6cb4D5560dEC30b0960c',
         deployProxy: false
     },
@@ -431,7 +431,7 @@ The following events will be emitted:
 ```typescript
   {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   status: 'PENDING',
   transaction: {
     ...
@@ -439,7 +439,7 @@ The following events will be emitted:
 }
 {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   status: 'COMPLETE',
   contractAddress: '0xa7b2ab323cD2504689637A0b503262A337ab87d6',
   receipt: {
@@ -448,7 +448,7 @@ The following events will be emitted:
 }
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'initialize(address)',
   status: 'PENDING',
   transaction: {
@@ -457,7 +457,7 @@ The following events will be emitted:
 }
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'initialize(address)',
   status: 'COMPLETE',
   receipt: {
@@ -466,7 +466,7 @@ The following events will be emitted:
 }
 {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   status: 'PENDING',
   transaction: {
     ...
@@ -474,7 +474,7 @@ The following events will be emitted:
 }
 {
   type: 'PROXY_DEPLOYMENT',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   status: 'COMPLETE',
   contractAddress: '0x8fE3f0fd1bc2aCDA6cf3712Cd9C7858B8195DC8E',
   receipt: {
@@ -483,7 +483,7 @@ The following events will be emitted:
 }
 {
   type: 'TRANSACTION',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   functionName: 'initialize(address)',
   status: 'PENDING',
   transaction: {
@@ -492,7 +492,7 @@ The following events will be emitted:
 }
 {
   type: 'TRANSACTION',
-  contractName: 'KeyManager',
+  contractName: 'LSP6KeyManager',
   functionName: 'initialize(address)',
   status: 'COMPLETE',
   receipt: {
@@ -501,7 +501,7 @@ The following events will be emitted:
 }
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'setData(bytes32[],bytes[])',
   status: 'PENDING',
   transaction: {
@@ -510,7 +510,7 @@ The following events will be emitted:
 }
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'setData(bytes32[],bytes[])',
   status: 'COMPLETE',
   receipt: {
@@ -520,7 +520,7 @@ The following events will be emitted:
 {
   type: 'TRANSACTION',
   status: 'PENDING',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'transferOwnership(address)',
   transaction: {
     ...
@@ -528,7 +528,7 @@ The following events will be emitted:
 }
 {
   type: 'TRANSACTION',
-  contractName: 'ERC725Account',
+  contractName: 'LSP0ERC725Account',
   functionName: 'transferOwnership(address)',
   status: 'COMPLETE',
   receipt: {
@@ -536,13 +536,13 @@ The following events will be emitted:
   }
 }
 {
-  ERC725Account: {
+  LSP0ERC725Account: {
     address: '0xa7b2ab323cD2504689637A0b503262A337ab87d6',
     receipt: {
       ...
     }
   },
-  KeyManager: {
+  LSP6KeyManager: {
     address: '0x8fE3f0fd1bc2aCDA6cf3712Cd9C7858B8195DC8E',
     receipt: {
       ...

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -431,7 +431,7 @@ observable.subscribe({
     console.error(error);
   },
   complete: () => {
-    console.log('Digital Asset deployment completed');
+    console.log('Universal Profile deployment completed');
   },
 });```
 

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -423,8 +423,17 @@ const observable = await lspFactory.UniversalProfile.deploy({...}, {
   deployReactive: true
 });
 
-observable.subscribe();
-```
+observable.subscribe({
+  next: (deploymentEvent) => {
+    console.log(deploymentEvent);
+  },
+  error: (error) => {
+    console.error(error);
+  },
+  complete: () => {
+    console.log('Digital Asset deployment completed');
+  },
+});```
 
 The following events will be emitted:
 
@@ -549,4 +558,5 @@ The following events will be emitted:
     }
   }
 }
+Digital Asset deployment completed
 ```

--- a/src/lib/classes/lsp3-universal-profile.spec.ts
+++ b/src/lib/classes/lsp3-universal-profile.spec.ts
@@ -25,7 +25,7 @@ import {
 import { getDeployedByteCode } from '../helpers/deployment.helper';
 
 import { lsp3ProfileJson } from './../../../test/lsp3-profile.mock';
-import { DeployedContracts, DeploymentEvent } from './../interfaces';
+import { ContractNames, DeployedContracts, DeploymentEvent } from './../interfaces';
 import { ProxyDeployer } from './proxy-deployer';
 
 jest.setTimeout(60000);
@@ -58,12 +58,12 @@ describe('LSP3UniversalProfile', () => {
         it('should deploy and set LSP3Profile data', async () => {
           signer = signers[0];
 
-          const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
+          const { LSP0ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
             controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
             lsp3Profile: lsp3ProfileMetadata,
           });
 
-          universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
+          universalProfile = UniversalProfile__factory.connect(LSP0ERC725Account.address, signer);
 
           const data = await universalProfile.getData([
             '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
@@ -90,7 +90,7 @@ describe('LSP3UniversalProfile', () => {
       beforeAll(async () => {
         signer = signers[0];
 
-        const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy(
+        const { LSP0ERC725Account, LSP6KeyManager } = await lspFactory.LSP3UniversalProfile.deploy(
           {
             controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
             lsp3Profile: lsp3ProfileJson.LSP3Profile,
@@ -100,8 +100,8 @@ describe('LSP3UniversalProfile', () => {
           }
         );
 
-        universalProfile = UniversalProfile__factory.connect(ERC725Account.address, signer);
-        keyManager = KeyManager;
+        universalProfile = UniversalProfile__factory.connect(LSP0ERC725Account.address, signer);
+        keyManager = LSP6KeyManager;
       });
 
       it('should deploy and set LSP3Profile data', async () => {
@@ -124,11 +124,14 @@ describe('LSP3UniversalProfile', () => {
     beforeAll(async () => {
       uniqueController = signers[0];
 
-      const { ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
+      const { LSP0ERC725Account } = await lspFactory.LSP3UniversalProfile.deploy({
         controllerAddresses: [uniqueController.address],
       });
 
-      universalProfile = UniversalProfile__factory.connect(ERC725Account.address, uniqueController);
+      universalProfile = UniversalProfile__factory.connect(
+        LSP0ERC725Account.address,
+        uniqueController
+      );
     });
 
     it('controller address should have DEFAULT_PERMISSIONS set', async () => {
@@ -161,17 +164,17 @@ describe('LSP3UniversalProfile', () => {
       firstControllerAddress = signers[0].address;
       secondControllerAddress = signers[1].address;
 
-      const { ERC725Account, KeyManager } = await lspFactory.LSP3UniversalProfile.deploy({
+      const { LSP0ERC725Account, LSP6KeyManager } = await lspFactory.LSP3UniversalProfile.deploy({
         controllerAddresses: [firstControllerAddress, secondControllerAddress],
       });
 
       universalProfile = new ethers.Contract(
-        ERC725Account.address,
+        LSP0ERC725Account.address,
         UniversalProfileContract.abi,
         provider
       );
 
-      keyManager = new ethers.Contract(KeyManager.address, KeyManagerContract.abi, provider);
+      keyManager = new ethers.Contract(LSP6KeyManager.address, KeyManagerContract.abi, provider);
     });
 
     it('1st address should have DEFAULT_PERMISSIONS set', async () => {
@@ -240,14 +243,14 @@ describe('LSP3UniversalProfile', () => {
         next: (deploymentEvent: DeploymentEvent) => {
           if (
             deploymentEvent.receipt?.contractAddress &&
-            deploymentEvent.contractName === 'ERC725Account'
+            deploymentEvent.contractName === ContractNames.ERC725_Account
           ) {
             erc725Address = deploymentEvent.receipt.contractAddress;
           }
 
           if (
             deploymentEvent.receipt?.contractAddress &&
-            deploymentEvent.contractName === 'KeyManager'
+            deploymentEvent.contractName === ContractNames.KEY_MANAGER
           ) {
             keyManagerAddress = deploymentEvent.receipt.contractAddress;
           }
@@ -273,9 +276,9 @@ describe('LSP3UniversalProfile', () => {
       it('Should not deploy base contracts', async () => {
         await testUPDeployment(
           {
-            ERC725Account: { deployProxy: false },
-            KeyManager: { deployProxy: false },
-            UniversalReceiverDelegate: { deployProxy: false },
+            LSP0ERC725Account: { deployProxy: false },
+            LSP6KeyManager: { deployProxy: false },
+            LSP1UniversalReceiverDelegate: { deployProxy: false },
           },
           3,
           lspFactory,
@@ -289,9 +292,9 @@ describe('LSP3UniversalProfile', () => {
       it('Should deploy only ERC725 Base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            ERC725Account: { deployProxy: true },
-            KeyManager: { deployProxy: false },
-            UniversalReceiverDelegate: { deployProxy: false },
+            LSP0ERC725Account: { deployProxy: true },
+            LSP6KeyManager: { deployProxy: false },
+            LSP1UniversalReceiverDelegate: { deployProxy: false },
           },
           4,
           lspFactory,
@@ -300,8 +303,8 @@ describe('LSP3UniversalProfile', () => {
       });
       it('UP contract bytecode should contain base contract address', async () => {
         await testProxyBytecodeContainsAddress(
-          deployedContracts.ERC725Account.address,
-          deployedContracts.ERC725AccountBaseContract.address,
+          deployedContracts.LSP0ERC725Account.address,
+          deployedContracts.LSP0ERC725AccountBaseContract.address,
           provider
         );
       });
@@ -312,9 +315,9 @@ describe('LSP3UniversalProfile', () => {
       it('Should deploy only KeyManager Base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            ERC725Account: { deployProxy: false },
-            KeyManager: { deployProxy: true },
-            UniversalReceiverDelegate: { deployProxy: false },
+            LSP0ERC725Account: { deployProxy: false },
+            LSP6KeyManager: { deployProxy: true },
+            LSP1UniversalReceiverDelegate: { deployProxy: false },
           },
           4,
           lspFactory,
@@ -323,8 +326,8 @@ describe('LSP3UniversalProfile', () => {
       });
       it('KeyManager contract bytecode should contain base contract address', async () => {
         await testProxyBytecodeContainsAddress(
-          deployedContracts.KeyManager.address,
-          deployedContracts.KeyManagerBaseContract.address,
+          deployedContracts.LSP6KeyManager.address,
+          deployedContracts.LSP6KeyManagerBaseContract.address,
           provider
         );
       });
@@ -335,9 +338,9 @@ describe('LSP3UniversalProfile', () => {
       it('Should deploy only URD Base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            ERC725Account: { deployProxy: false },
-            KeyManager: { deployProxy: false },
-            UniversalReceiverDelegate: { deployProxy: true },
+            LSP0ERC725Account: { deployProxy: false },
+            LSP6KeyManager: { deployProxy: false },
+            LSP1UniversalReceiverDelegate: { deployProxy: true },
           },
           4,
           lspFactory,
@@ -347,8 +350,8 @@ describe('LSP3UniversalProfile', () => {
 
       it('KeyManager contract bytecode should contain base contract address', async () => {
         await testProxyBytecodeContainsAddress(
-          deployedContracts.UniversalReceiverDelegate.address,
-          deployedContracts.UniversalReceiverDelegateBaseContract.address,
+          deployedContracts.LSP1UniversalReceiverDelegate.address,
+          deployedContracts.LSP1UniversalReceiverDelegateBaseContract.address,
           provider
         );
       });
@@ -358,9 +361,9 @@ describe('LSP3UniversalProfile', () => {
       it('Should deploy with all baseContracts', async () => {
         await testUPDeployment(
           {
-            ERC725Account: { deployProxy: true },
-            KeyManager: { deployProxy: true },
-            UniversalReceiverDelegate: { deployProxy: true },
+            LSP0ERC725Account: { deployProxy: true },
+            LSP6KeyManager: { deployProxy: true },
+            LSP1UniversalReceiverDelegate: { deployProxy: true },
           },
           6,
           lspFactory,
@@ -376,7 +379,7 @@ describe('LSP3UniversalProfile', () => {
       it('should not deploy UP base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            ERC725Account: {
+            LSP0ERC725Account: {
               version: UniversalProfile__factory.bytecode,
             },
           },
@@ -387,14 +390,14 @@ describe('LSP3UniversalProfile', () => {
       });
       it('should be able to setData', async () => {
         await testSetData(
-          deployedContracts.ERC725Account.address,
-          deployedContracts.KeyManager.address,
+          deployedContracts.LSP0ERC725Account.address,
+          deployedContracts.LSP6KeyManager.address,
           signers[0]
         );
       });
       it('should have deployed bytecode', async () => {
         const bytecode = await getDeployedByteCode(
-          deployedContracts.ERC725Account.address,
+          deployedContracts.LSP0ERC725Account.address,
           provider
         );
 
@@ -409,7 +412,7 @@ describe('LSP3UniversalProfile', () => {
 
         deployedContracts = await testUPDeployment(
           {
-            KeyManager: { version: LSP6KeyManager__factory.bytecode },
+            LSP6KeyManager: { version: LSP6KeyManager__factory.bytecode },
           },
           4,
           lspFactory,
@@ -418,13 +421,16 @@ describe('LSP3UniversalProfile', () => {
       });
       it('should be able to setData', async () => {
         await testSetData(
-          deployedContracts.ERC725Account.address,
-          deployedContracts.KeyManager.address,
+          deployedContracts.LSP0ERC725Account.address,
+          deployedContracts.LSP6KeyManager.address,
           signers[0]
         );
       });
       it('should have deployed bytecode', async () => {
-        const bytecode = await getDeployedByteCode(deployedContracts.KeyManager.address, provider);
+        const bytecode = await getDeployedByteCode(
+          deployedContracts.LSP6KeyManager.address,
+          provider
+        );
 
         expect(bytecode).not.toEqual('0x');
         expect(bytecode.length).toBeGreaterThan(100);
@@ -435,7 +441,7 @@ describe('LSP3UniversalProfile', () => {
       it('should not deploy KeyManager base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            UniversalReceiverDelegate: {
+            LSP1UniversalReceiverDelegate: {
               version: LSP1UniversalReceiverDelegateUP__factory.bytecode,
             },
           },
@@ -446,14 +452,14 @@ describe('LSP3UniversalProfile', () => {
       });
       it('should be able to setData', async () => {
         await testSetData(
-          deployedContracts.ERC725Account.address,
-          deployedContracts.KeyManager.address,
+          deployedContracts.LSP0ERC725Account.address,
+          deployedContracts.LSP6KeyManager.address,
           signers[0]
         );
       });
       it('should have deployed bytecode', async () => {
         const bytecode = await getDeployedByteCode(
-          deployedContracts.UniversalReceiverDelegate.address,
+          deployedContracts.LSP1UniversalReceiverDelegate.address,
           provider
         );
 
@@ -477,7 +483,7 @@ describe('LSP3UniversalProfile', () => {
       it('should not deploy UP base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            ERC725Account: { version: baseContracts.universalProfile.address },
+            LSP0ERC725Account: { version: baseContracts.universalProfile.address },
           },
           4,
           lspFactory,
@@ -486,14 +492,14 @@ describe('LSP3UniversalProfile', () => {
       });
       it('should be able to setData', async () => {
         await testSetData(
-          deployedContracts.ERC725Account.address,
-          deployedContracts.KeyManager.address,
+          deployedContracts.LSP0ERC725Account.address,
+          deployedContracts.LSP6KeyManager.address,
           signers[0]
         );
       });
       it('UP contract bytecode should contain base contract address', async () => {
         await testProxyBytecodeContainsAddress(
-          deployedContracts.ERC725Account.address,
+          deployedContracts.LSP0ERC725Account.address,
           baseContracts.universalProfile.address,
           provider
         );
@@ -506,7 +512,7 @@ describe('LSP3UniversalProfile', () => {
       it('should not deploy KeyManager base contract', async () => {
         deployedContracts = await testUPDeployment(
           {
-            KeyManager: { version: baseContracts.keyManager.address },
+            LSP6KeyManager: { version: baseContracts.keyManager.address },
           },
           4,
           lspFactory,
@@ -515,14 +521,14 @@ describe('LSP3UniversalProfile', () => {
       });
       it('should be able to setData', async () => {
         await testSetData(
-          deployedContracts.ERC725Account.address,
-          deployedContracts.KeyManager.address,
+          deployedContracts.LSP0ERC725Account.address,
+          deployedContracts.LSP6KeyManager.address,
           signers[0]
         );
       });
       it('KeyManager contract bytecode should contain base contract address', async () => {
         await testProxyBytecodeContainsAddress(
-          deployedContracts.KeyManager.address,
+          deployedContracts.LSP6KeyManager.address,
           baseContracts.keyManager.address,
           provider
         );
@@ -534,7 +540,7 @@ describe('LSP3UniversalProfile', () => {
       it('should not deploy URD contracts', async () => {
         deployedContracts = await testUPDeployment(
           {
-            UniversalReceiverDelegate: {
+            LSP1UniversalReceiverDelegate: {
               version: baseContracts.universalReceiverDelegate.address,
             },
           },
@@ -545,14 +551,14 @@ describe('LSP3UniversalProfile', () => {
       });
       it('should be able to setData', async () => {
         await testSetData(
-          deployedContracts.ERC725Account.address,
-          deployedContracts.KeyManager.address,
+          deployedContracts.LSP0ERC725Account.address,
+          deployedContracts.LSP6KeyManager.address,
           signers[0]
         );
       });
       it('should set provided LSP1 key on the UP', async () => {
         const universalProfile = UniversalProfile__factory.connect(
-          deployedContracts.ERC725Account.address,
+          deployedContracts.LSP0ERC725Account.address,
           signers[0]
         );
 
@@ -566,7 +572,7 @@ describe('LSP3UniversalProfile', () => {
       it('should use provided address as base contract if deployProxy set to true', async () => {
         deployedContracts = await testUPDeployment(
           {
-            UniversalReceiverDelegate: {
+            LSP1UniversalReceiverDelegate: {
               version: baseContracts.universalReceiverDelegate.address,
               deployProxy: true,
             },
@@ -578,7 +584,7 @@ describe('LSP3UniversalProfile', () => {
       });
       it('should set deployed URD contract on the UP', async () => {
         const universalProfile = UniversalProfile__factory.connect(
-          deployedContracts.ERC725Account.address,
+          deployedContracts.LSP0ERC725Account.address,
           signers[0]
         );
 
@@ -586,11 +592,11 @@ describe('LSP3UniversalProfile', () => {
 
         const checkedsumResult = ethers.utils.getAddress(data[0]);
 
-        expect(checkedsumResult).toEqual(deployedContracts.UniversalReceiverDelegate.address);
+        expect(checkedsumResult).toEqual(deployedContracts.LSP1UniversalReceiverDelegate.address);
       });
       it('URD contract bytecode should contain base contract address', async () => {
         await testProxyBytecodeContainsAddress(
-          deployedContracts.UniversalReceiverDelegate.address,
+          deployedContracts.LSP1UniversalReceiverDelegate.address,
           baseContracts.universalReceiverDelegate.address,
           provider
         );

--- a/src/lib/classes/lsp3-universal-profile.ts
+++ b/src/lib/classes/lsp3-universal-profile.ts
@@ -98,19 +98,19 @@ export class LSP3UniversalProfile {
 
     // 0 > Check for existing base contracts and deploy
     const defaultUPBaseContractAddress =
-      deploymentConfiguration?.ERC725Account?.libAddress ??
+      deploymentConfiguration?.LSP0ERC725Account?.libAddress ??
       contractVersions[this.options.chainId]?.contracts?.ERC725Account?.versions[
-        deploymentConfiguration?.ERC725Account?.version ?? defaultContractVersion
+        deploymentConfiguration?.LSP0ERC725Account?.version ?? defaultContractVersion
       ];
     const defaultUniversalReceiverAddress =
-      deploymentConfiguration?.UniversalReceiverDelegate?.libAddress ??
+      deploymentConfiguration?.LSP1UniversalReceiverDelegate?.libAddress ??
       contractVersions[this.options.chainId]?.contracts?.UniversalReceiverDelegate?.versions[
-        deploymentConfiguration?.UniversalReceiverDelegate?.version ?? defaultContractVersion
+        deploymentConfiguration?.LSP1UniversalReceiverDelegate?.version ?? defaultContractVersion
       ];
     const defaultKeyManagerBaseContractAddress =
-      deploymentConfiguration?.KeyManager?.libAddress ??
+      deploymentConfiguration?.LSP6KeyManager?.libAddress ??
       contractVersions[this.options.chainId]?.contracts?.KeyManager?.versions[
-        deploymentConfiguration?.KeyManager?.version ?? defaultContractVersion
+        deploymentConfiguration?.LSP6KeyManager?.version ?? defaultContractVersion
       ];
 
     const baseContractsToDeploy$ = shouldDeployUniversalProfileBaseContracts$(
@@ -128,9 +128,9 @@ export class LSP3UniversalProfile {
     );
 
     const deployUniversalReceiverProxy =
-      typeof deploymentConfiguration?.UniversalReceiverDelegate?.deployProxy === 'undefined'
+      typeof deploymentConfiguration?.LSP1UniversalReceiverDelegate?.deployProxy === 'undefined'
         ? contractVersions[this.options.chainId]?.contracts?.UniversalReceiverDelegate?.baseContract
-        : deploymentConfiguration?.UniversalReceiverDelegate?.deployProxy;
+        : deploymentConfiguration?.LSP1UniversalReceiverDelegate?.deployProxy;
 
     const baseContractAddresses$ = universalProfileBaseContractAddresses$(
       baseContractDeployment$,
@@ -144,7 +144,7 @@ export class LSP3UniversalProfile {
     const account$ = accountDeployment$(
       this.signer,
       baseContractAddresses$,
-      deploymentConfiguration?.ERC725Account?.byteCode
+      deploymentConfiguration?.LSP0ERC725Account?.byteCode
     );
 
     const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
@@ -155,7 +155,7 @@ export class LSP3UniversalProfile {
       account$,
       baseContractAddresses$,
       signerIsUniversalProfile$,
-      deploymentConfiguration?.KeyManager?.byteCode
+      deploymentConfiguration?.LSP6KeyManager?.byteCode
     );
 
     // 3 > deploys UniversalReceiverDelegate
@@ -163,11 +163,11 @@ export class LSP3UniversalProfile {
       this.signer,
       this.options.provider,
       baseContractAddresses$,
-      deploymentConfiguration?.UniversalReceiverDelegate?.libAddress,
+      deploymentConfiguration?.LSP1UniversalReceiverDelegate?.libAddress,
       contractVersions[this.options.chainId]?.contracts?.UniversalReceiverDelegate?.versions[
-        deploymentConfiguration?.UniversalReceiverDelegate?.version ?? defaultContractVersion
+        deploymentConfiguration?.LSP1UniversalReceiverDelegate?.version ?? defaultContractVersion
       ],
-      deploymentConfiguration?.UniversalReceiverDelegate?.byteCode
+      deploymentConfiguration?.LSP1UniversalReceiverDelegate?.byteCode
     );
 
     // 4 set permissions, profile and universal receiver + transfer ownership to KeyManager

--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -134,7 +134,7 @@ export class LSP7DigitalAsset {
       signerIsUniversalProfile$
     );
 
-    const deployment$ = deploymentWithContractsOnCompletion$(
+    const deployment$ = deploymentWithContractsOnCompletion$<DeployedLSP7DigitalAsset>(
       concat([baseContractDeployment$, digitalAsset$, setLSP4AndTransferOwnership$]).pipe(
         concatAll()
       )

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -133,7 +133,7 @@ export class LSP8IdentifiableDigitalAsset {
       signerIsUniversalProfile$
     );
 
-    const deployment$ = deploymentWithContractsOnCompletion$(
+    const deployment$ = deploymentWithContractsOnCompletion$<DeployedLSP8IdentifiableDigitalAsset>(
       concat([baseContractDeployment$, digitalAsset$, setLSP4AndTransferOwnership$]).pipe(
         concatAll()
       )

--- a/src/lib/helpers/deployment.helper.spec.ts
+++ b/src/lib/helpers/deployment.helper.spec.ts
@@ -12,7 +12,7 @@ describe('waitForReceipt', () => {
   describe('with type PROXY', () => {
     it('should return a new deployment event with the receipt', (done) => {
       const expectedDeploymentEvent =
-        defaultDeploymentEvents[DeploymentType.PROXY].ERC725Account.deployment;
+        defaultDeploymentEvents[DeploymentType.PROXY].LSP0ERC725Account.deployment;
       const deploymentEvent$ = of(expectedDeploymentEvent);
       const receipt$ = waitForReceipt(deploymentEvent$);
 
@@ -30,7 +30,7 @@ describe('waitForReceipt', () => {
 
     it('should return a new deployment event with the receipt, functionName', (done) => {
       const expectedDeploymentEvent =
-        defaultDeploymentEvents[DeploymentType.PROXY].ERC725Account.initialize;
+        defaultDeploymentEvents[DeploymentType.PROXY].LSP0ERC725Account.initialize;
       const expectedDeploymentEvent$ = of(expectedDeploymentEvent);
       const receipt$ = waitForReceipt(expectedDeploymentEvent$);
 
@@ -49,7 +49,7 @@ describe('waitForReceipt', () => {
 
     it('should throw an error incase transaction.wait() fails/errors', (done) => {
       const expectedDeploymentEvent$ = of(
-        defaultDeploymentEvents[DeploymentType.PROXY].ERC725Account.error
+        defaultDeploymentEvents[DeploymentType.PROXY].LSP0ERC725Account.error
       );
       const receipt$ = waitForReceipt(expectedDeploymentEvent$);
 

--- a/src/lib/helpers/deployment.helper.ts
+++ b/src/lib/helpers/deployment.helper.ts
@@ -176,8 +176,9 @@ export function getDeployedByteCode(
   return provider.getCode(contractAddress);
 }
 
-export function deploymentWithContractsOnCompletion$(deployment$: Observable<DeploymentEvent>) {
-  const contractAccumulator = {};
+export function deploymentWithContractsOnCompletion$<T>(deployment$: Observable<DeploymentEvent>) {
+  const contractAccumulator = {} as T;
+
   return deployment$.pipe(
     tap((deploymentEvent) => {
       if (!deploymentEvent.receipt || !deploymentEvent.receipt.contractAddress) {

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -4,9 +4,9 @@ import { LSP3ProfileDataForEncoding, ProfileDataBeforeUpload } from './lsp3-prof
 import { IPFSGateway, UploadOptions } from './profile-upload-options';
 
 export enum ContractNames {
-  ERC725_Account = 'ERC725Account',
-  KEY_MANAGER = 'KeyManager',
-  UNIVERSAL_RECEIVER = 'UniversalReceiverDelegate',
+  ERC725_Account = 'LSP0ERC725Account',
+  KEY_MANAGER = 'LSP6KeyManager',
+  UNIVERSAL_RECEIVER = 'LSP1UniversalReceiverDelegate',
 }
 
 export interface ControllerOptions {
@@ -19,20 +19,16 @@ export interface ControllerOptions {
  */
 export interface ProfileDeploymentOptions {
   controllerAddresses: (string | ControllerOptions)[];
-  baseContractAddresses?: {
-    erc725Account?: string;
-    universalReceiverDelegate?: string;
-    keyManager?: string;
-  };
   lsp3Profile?: ProfileDataBeforeUpload | LSP3ProfileDataForEncoding | string;
 }
+
 export interface DeployedContracts {
-  ERC725Account?: DeployedContract;
-  ERC725AccountBaseContract?: DeployedContract;
-  KeyManager: DeployedContract;
-  KeyManagerBaseContract: DeployedContract;
-  UniversalReceiverDelegate: DeployedContract;
-  UniversalReceiverDelegateBaseContract: DeployedContract;
+  LSP0ERC725Account?: DeployedContract;
+  LSP0ERC725AccountBaseContract?: DeployedContract;
+  LSP6KeyManager: DeployedContract;
+  LSP6KeyManagerBaseContract: DeployedContract;
+  LSP1UniversalReceiverDelegate: DeployedContract;
+  LSP1UniversalReceiverDelegateBaseContract: DeployedContract;
 }
 
 export interface BaseContractAddresses {
@@ -44,9 +40,10 @@ export interface BaseContractAddresses {
 interface ContractDeploymentOptionsBase {
   version?: string;
   ipfsGateway?: IPFSGateway;
+  LSP0ERC725Account?: ContractOptions;
   ERC725Account?: ContractOptions;
-  KeyManager?: ContractOptions;
-  UniversalReceiverDelegate?: ContractOptions;
+  LSP6KeyManager?: ContractOptions;
+  LSP1UniversalReceiverDelegate?: ContractOptions;
 }
 
 export interface ContractDeploymentOptionsReactive extends ContractDeploymentOptionsBase {
@@ -71,8 +68,8 @@ interface ContractConfiguration {
 export interface UniversalProfileDeploymentConfiguration {
   version?: string;
   uploadOptions?: UploadOptions;
-  ERC725Account?: ContractConfiguration;
-  KeyManager?: ContractConfiguration;
-  UniversalReceiverDelegate?: ContractConfiguration;
+  LSP0ERC725Account?: ContractConfiguration;
+  LSP6KeyManager?: ContractConfiguration;
+  LSP1UniversalReceiverDelegate?: ContractConfiguration;
   deployReactive: boolean;
 }

--- a/src/lib/services/base-contract.service.ts
+++ b/src/lib/services/base-contract.service.ts
@@ -161,26 +161,26 @@ export function shouldDeployUniversalProfileBaseContracts$(
     shouldDeployBaseContract$(
       provider,
       contractVersions[chainId]?.contracts?.ERC725Account?.baseContract,
-      contractDeploymentOptions?.ERC725Account?.deployProxy,
+      contractDeploymentOptions?.LSP0ERC725Account?.deployProxy,
       defaultUPBaseContractAddress,
-      contractDeploymentOptions?.ERC725Account?.libAddress,
-      contractDeploymentOptions?.ERC725Account?.byteCode
+      contractDeploymentOptions?.LSP0ERC725Account?.libAddress,
+      contractDeploymentOptions?.LSP0ERC725Account?.byteCode
     ),
     shouldDeployBaseContract$(
       provider,
       contractVersions[chainId]?.contracts?.UniversalReceiverDelegate?.baseContract,
-      contractDeploymentOptions?.UniversalReceiverDelegate?.deployProxy,
+      contractDeploymentOptions?.LSP1UniversalReceiverDelegate?.deployProxy,
       defaultUniversalReceiverBaseContractAddress,
-      contractDeploymentOptions?.UniversalReceiverDelegate?.libAddress,
-      contractDeploymentOptions?.UniversalReceiverDelegate?.byteCode
+      contractDeploymentOptions?.LSP1UniversalReceiverDelegate?.libAddress,
+      contractDeploymentOptions?.LSP1UniversalReceiverDelegate?.byteCode
     ),
     shouldDeployBaseContract$(
       provider,
       contractVersions[chainId]?.contracts?.KeyManager?.baseContract,
-      contractDeploymentOptions?.KeyManager?.deployProxy,
+      contractDeploymentOptions?.LSP6KeyManager?.deployProxy,
       defaultKeyManagerBaseContractAddress,
-      contractDeploymentOptions?.KeyManager?.libAddress,
-      contractDeploymentOptions?.KeyManager?.byteCode
+      contractDeploymentOptions?.LSP6KeyManager?.libAddress,
+      contractDeploymentOptions?.LSP6KeyManager?.byteCode
     ),
   ]).pipe(shareReplay());
 }
@@ -192,16 +192,16 @@ export function universalProfileBaseContractAddresses$(
   contractDeploymentOptions?: UniversalProfileDeploymentConfiguration,
   deployUniversalReceiverProxy?: boolean
 ) {
-  const providedUPBaseContractAddress = contractDeploymentOptions?.ERC725Account?.libAddress;
+  const providedUPBaseContractAddress = contractDeploymentOptions?.LSP0ERC725Account?.libAddress;
   const providedUniversalReceiverContractAddress =
-    contractDeploymentOptions?.UniversalReceiverDelegate?.libAddress;
-  const providedKeyManagerContractAddress = contractDeploymentOptions?.KeyManager?.libAddress;
+    contractDeploymentOptions?.LSP1UniversalReceiverDelegate?.libAddress;
+  const providedKeyManagerContractAddress = contractDeploymentOptions?.LSP6KeyManager?.libAddress;
 
   const baseContractAddresses: BaseContractAddresses = {
     [UniversalProfileContractNames.ERC725_Account]:
       providedUPBaseContractAddress ??
-      (contractDeploymentOptions?.ERC725Account?.deployProxy !== false &&
-        !contractDeploymentOptions?.ERC725Account?.byteCode)
+      (contractDeploymentOptions?.LSP0ERC725Account?.deployProxy !== false &&
+        !contractDeploymentOptions?.LSP0ERC725Account?.byteCode)
         ? defaultUPBaseContractAddress
         : null,
     [UniversalProfileContractNames.UNIVERSAL_RECEIVER]:
@@ -210,8 +210,8 @@ export function universalProfileBaseContractAddresses$(
         : null,
     [UniversalProfileContractNames.KEY_MANAGER]:
       providedKeyManagerContractAddress ??
-      (contractDeploymentOptions?.KeyManager?.deployProxy !== false &&
-        !contractDeploymentOptions?.KeyManager?.byteCode)
+      (contractDeploymentOptions?.LSP6KeyManager?.deployProxy !== false &&
+        !contractDeploymentOptions?.LSP6KeyManager?.byteCode)
         ? defaultKeyManagerBaseContractAddress
         : null,
   };

--- a/src/lib/services/key-manager.service.ts
+++ b/src/lib/services/key-manager.service.ts
@@ -37,7 +37,7 @@ export function keyManagerDeployment$(
         return keyManagerDeploymentForAccount$(
           signer,
           erc725AccountAddress,
-          baseContractAddress.KeyManager,
+          baseContractAddress.LSP6KeyManager,
           byteCode
         );
       }

--- a/src/lib/services/lsp3-account.service.ts
+++ b/src/lib/services/lsp3-account.service.ts
@@ -57,7 +57,7 @@ export function accountDeployment$(
     switchMap((baseContractAddresses) => {
       return accountDeploymentWithBaseContractAddress$(
         signer,
-        baseContractAddresses.ERC725Account,
+        baseContractAddresses.LSP0ERC725Account,
         bytecode
       );
     }),
@@ -531,24 +531,27 @@ export function isSignerUniversalProfile$(signer: Signer) {
 export function convertUniversalProfileConfigurationObject(
   contractDeploymentOptions: ContractDeploymentOptions
 ): UniversalProfileDeploymentConfiguration {
+  const erc725AccountConfig =
+    contractDeploymentOptions?.LSP0ERC725Account || contractDeploymentOptions?.ERC725Account;
+
   const {
     version: erc725AccountVersion,
     byteCode: erc725AccountBytecode,
     libAddress: erc725AccountLibAddress,
-  } = convertContractDeploymentOptionsVersion(contractDeploymentOptions?.ERC725Account?.version);
+  } = convertContractDeploymentOptionsVersion(erc725AccountConfig?.version);
 
   const {
     version: keyManagerVersion,
     byteCode: keyManagerBytecode,
     libAddress: keyManagerLibAddress,
-  } = convertContractDeploymentOptionsVersion(contractDeploymentOptions?.KeyManager?.version);
+  } = convertContractDeploymentOptionsVersion(contractDeploymentOptions?.LSP6KeyManager?.version);
 
   const {
     version: universalReceiverDelegateVersion,
     byteCode: universalReceiverDelegateBytecode,
     libAddress: universalReceiverDelegateLibAddress,
   } = convertContractDeploymentOptionsVersion(
-    contractDeploymentOptions?.UniversalReceiverDelegate?.version
+    contractDeploymentOptions?.LSP1UniversalReceiverDelegate?.version
   );
 
   return {
@@ -556,23 +559,23 @@ export function convertUniversalProfileConfigurationObject(
     uploadOptions: contractDeploymentOptions?.ipfsGateway
       ? { ipfsGateway: contractDeploymentOptions?.ipfsGateway }
       : undefined,
-    ERC725Account: {
+    LSP0ERC725Account: {
       version: erc725AccountVersion,
       byteCode: erc725AccountBytecode,
       libAddress: erc725AccountLibAddress,
-      deployProxy: contractDeploymentOptions?.ERC725Account?.deployProxy,
+      deployProxy: erc725AccountConfig?.deployProxy,
     },
-    KeyManager: {
+    LSP6KeyManager: {
       version: keyManagerVersion,
       byteCode: keyManagerBytecode,
       libAddress: keyManagerLibAddress,
-      deployProxy: contractDeploymentOptions?.KeyManager?.deployProxy,
+      deployProxy: contractDeploymentOptions?.LSP6KeyManager?.deployProxy,
     },
-    UniversalReceiverDelegate: {
+    LSP1UniversalReceiverDelegate: {
       version: universalReceiverDelegateVersion,
       byteCode: universalReceiverDelegateBytecode,
       libAddress: universalReceiverDelegateLibAddress,
-      deployProxy: contractDeploymentOptions?.UniversalReceiverDelegate?.deployProxy,
+      deployProxy: contractDeploymentOptions?.LSP1UniversalReceiverDelegate?.deployProxy,
     },
     deployReactive: contractDeploymentOptions?.deployReactive,
   };

--- a/src/lib/services/universal-receiver.service.ts
+++ b/src/lib/services/universal-receiver.service.ts
@@ -36,10 +36,10 @@ export function universalReceiverDelegateDeployment$(
 
   return forkJoin([defaultURDBytecode$, baseContractAddresses$]).pipe(
     switchMap(([defaultURDBytecode, baseContractAddresses]) => {
-      if (baseContractAddresses.UniversalReceiverDelegate || byteCode) {
+      if (baseContractAddresses.LSP1UniversalReceiverDelegate || byteCode) {
         return universalReceiverDelegateDeploymentWithBaseContractAddress$(
           signer,
-          baseContractAddresses.UniversalReceiverDelegate,
+          baseContractAddresses.LSP1UniversalReceiverDelegate,
           byteCode
         );
       }

--- a/test/test.utils.ts
+++ b/test/test.utils.ts
@@ -7,7 +7,7 @@ import { UniversalProfile__factory } from '../types/ethers-v5/factories/Universa
 import { LSP6KeyManager__factory } from '../types/ethers-v5/factories/LSP6KeyManager__factory';
 import { LSP1UniversalReceiverDelegateUP__factory } from '../types/ethers-v5/factories/LSP1UniversalReceiverDelegateUP__factory';
 import { ContractDeploymentOptions, LSPFactory } from '../build/main/src';
-import { DeployedContracts } from '../src/lib/interfaces';
+import { ContractNames, DeployedContracts } from '../src/lib/interfaces';
 import { getDeployedByteCode, getProxyByteCode } from '../src/lib/helpers/deployment.helper';
 import { providers } from 'ethers';
 import { getAddress } from 'ethers/lib/utils';
@@ -44,7 +44,7 @@ export async function testUPDeployment(
 
   expect(Object.keys(deployedContracts).length).toEqual(expectedContractNumber);
 
-  const contractNames = ['ERC725Account', 'KeyManager'];
+  const contractNames = [ContractNames.ERC725_Account, ContractNames.KEY_MANAGER];
 
   for (const contractName of contractNames) {
     if (
@@ -58,12 +58,12 @@ export async function testUPDeployment(
   }
 
   if (
-    contractDeploymentOptions?.UniversalReceiverDelegate?.deployProxy &&
-    !isAddress(contractDeploymentOptions?.UniversalReceiverDelegate.version)
+    contractDeploymentOptions?.LSP1UniversalReceiverDelegate?.deployProxy &&
+    !isAddress(contractDeploymentOptions?.LSP1UniversalReceiverDelegate.version)
   ) {
-    expect(deployedContracts[`UniversalReceiverDelegateBaseContract`]).toBeDefined();
+    expect(deployedContracts[`LSP1UniversalReceiverDelegateBaseContract`]).toBeDefined();
   } else {
-    expect(deployedContracts[`UniversalReceiverDelegateBaseContract`]).toBeUndefined();
+    expect(deployedContracts[`LSP1UniversalReceiverDelegateBaseContract`]).toBeUndefined();
   }
 
   return deployedContracts as DeployedContracts;


### PR DESCRIPTION
Renames Universal Profile contract names to use full LSP names. 

ERC725Account -> LSP0ERC725Account
KeyManager -> LSP6KeyManager
UniversalReceiverDelegate -> LSP1UniversalReceiverDelegate

e.g.
```js
 lspFactory.UniversalProfile.deploy({...}, {
  LSP0ERC725Account: {...}, // Can also be passed as ERC725Account
  LSP6KeyManager: {...},
  LSP1UniversalReceiverDelegate: {...}
});

```

returns 

```js
{
  LSP0ERC725Account: {
    address: '...',
    receipt: {
     ...
    }
  },
  LSP1UniversalReceiverDelegate: {
    address: '...',
    receipt: {
      ...
    }
  },
  LSP6KeyManager: {
    address: '...',
    receipt: {
    ...
    }
  }
}
```

Please merge https://github.com/lukso-network/tools-lsp-factory/pull/117 first