### PR TITLE
docs: minor updates to rective deployment examples and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [2.3.0](https://github.com/lukso-network/tools-lsp-factory/compare/v2.1.0...v2.3.0) (2022-05-30)
+## [2.3.0](https://github.com/lukso-network/tools-lsp-factory/compare/v2.2.0...v2.3.0) (2022-05-30)
 
 
 ### ⚠ BREAKING CHANGES

--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -107,9 +107,9 @@ await lspFactory.LSP7DigitalAsset.deploy(
       error: (error) => {
         console.error(error);
       },
-      complete: (digitalAsset) => {
+      complete: (contracts) => {
         console.log('Deployment Complete');
-        console.log(digitalAsset);
+        console.log(contracts.LSP7DigitalAsset);
       },
     },
   },
@@ -189,12 +189,10 @@ await lspFactory.LSP7DigitalAsset.deploy(
 }
 Deployment Complete
 {
-  LSP7DigitalAsset: {
-    address: '0x97053C386eaa49d6eAD7477220ca04EFcD857dde',
-    receipt: {
-      ...
-    },
-  }
+  address: '0x97053C386eaa49d6eAD7477220ca04EFcD857dde',
+  receipt: {
+    ...
+  },
 }
 */
 ```

--- a/docs/classes/lsp8-identifiable-digital-asset.md
+++ b/docs/classes/lsp8-identifiable-digital-asset.md
@@ -111,9 +111,9 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
       error: (error) => {
         console.error(error);
       },
-      complete: (digitalAsset) => {
+      complete: (contracts) => {
         console.log('Deployment Complete');
-        console.log(digitalAsset);
+        console.log(contracts.LSP8IdentifiableDigitalAsset);
       },
     },
   },
@@ -193,12 +193,10 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy(
 }
 Deployment Complete
 {
-  LSP8IdentifiableDigitalAsset: {
-    address: '0x2cA038832c15E61b83d47414Eb53818a45e0E142',
-    receipt: {
-      ...
-    },
-  }
+  address: '0x2cA038832c15E61b83d47414Eb53818a45e0E142',
+  receipt: {
+    ...
+  },
 }
 */
 ```

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -404,7 +404,7 @@ The `complete` callback will be called with the same contracts object which is r
 #### LSP7 Deployment Events
 
 ```javascript title="Reactive deployment of an LSP7 Digital Asset"
-const digitalAsset = lspFactory.LSP7DigitalAsset.deploy({...}, {
+const contracts = lspFactory.LSP7DigitalAsset.deploy({...}, {
   onDeployEvents: {
     next: (deploymentEvent) => {
       console.log(deploymentEvent);
@@ -412,9 +412,9 @@ const digitalAsset = lspFactory.LSP7DigitalAsset.deploy({...}, {
     error: (error) => {
       console.error(error);
     },
-    complete: (digitalAsset) => {
+    complete: (contracts) => {
       console.log('Digital Asset deployment completed');
-      console.log(digitalAsset);
+      console.log(contracts.LSP7DigitalAsset);
     },
   }
 });
@@ -493,12 +493,10 @@ const digitalAsset = lspFactory.LSP7DigitalAsset.deploy({...}, {
 }
 Digital Asset deployment completed
 {
-  LSP7DigitalAsset: {
-    address: '0x97053C386eaa49d6eAD7477220ca04EFcD857dde',
-    receipt: {
-      ...
-    },
-  }
+  address: '0x97053C386eaa49d6eAD7477220ca04EFcD857dde',
+  receipt: {
+    ...
+  },
 }
 */
 ```
@@ -506,7 +504,7 @@ Digital Asset deployment completed
 #### LSP8 Deployment Events
 
 ```typescript title="Reactive deployment of an LSP8 Identifiable Digital Asset"
-const digitalAsset = lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
+const contracts = lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
   onDeployEvents: {
     next: (deploymentEvent) => {
       console.log(deploymentEvent);
@@ -514,9 +512,9 @@ const digitalAsset = lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
     error: (error) => {
       console.error(error);
     },
-    complete: (digitalAsset) => {
+    complete: (contracts) => {
       console.log('Digital Asset deployment completed');
-      console.log(digitalAsset);
+      console.log(contracts.LSP8IdentifiableDigitalAsset);
     },
   }
 });
@@ -595,12 +593,10 @@ const digitalAsset = lspFactory.LSP8IdentifiableDigitalAsset.deploy({...}, {
 }
 Digital Asset deployment completed
 {
-  LSP8IdentifiableDigitalAsset: {
-    address: '0x2cA038832c15E61b83d47414Eb53818a45e0E142',
-    receipt: {
-      ...
-    },
-  }
+  address: '0x2cA038832c15E61b83d47414Eb53818a45e0E142',
+  receipt: {
+    ...
+  },
 }
 */
 


### PR DESCRIPTION
Minor updates to reactive deployment examples to show show logging `contracts.LSP7DigitalAsset` on complete.

Fix changelog saying diff is from 2.1.0 -> 2.3.0. Now says 2.2.0 -> 2.3.0.