### PR TITLE
improvement: allow passing metadata with lsp3/lsp4 keys

### DIFF
--- a/docs/classes/lsp4-digital-asset-metadata.md
+++ b/docs/classes/lsp4-digital-asset-metadata.md
@@ -28,6 +28,12 @@ If `options` are not specified in the function call, and the function is used on
 | `images` (optional) | Array         | An Array of images where each image element is a JavaScript File object or an Array of image metadata Objects for different sizes of the same image. |
 | `assets` (optional) | Array         | An Array of assets where each asset is a JavaScript File object or an asset metadata Object.                                                         |
 
+OR
+
+| Name           | Type   | Description                                                                             |
+| :------------- | :----- | :-------------------------------------------------------------------------------------- |
+| `LSP4Metadata` | Object | Object containing `description`, `links`, `icon`, `images`, `assets` as described above |
+
 #### 2. `options` - Object (optional)
 
 | Name                                                                        | Type             | Description                                                                                                 |
@@ -72,6 +78,38 @@ await LSP4DigitalAssetMetadata.uploadMetadata(
 */
 ```
 
+```javascript title="Uploading LSP4Metadata"
+const image = new File();
+const icon = new File();
+const asset = new File();
+
+await LSP4DigitalAssetMetadata.uploadMetadata(
+    {
+      LSP4Metadata: {
+        description: "Digital Asset",
+        assets: [asset],
+        images: [image],
+        icon: icon,
+        links: [{ title: "Cool", url: "cool.com" }],
+      }
+    };
+);
+/**
+{
+  lsp4Metadata: {
+    LSP4Metadata: {
+      description: 'Digital Asset',
+      assets: [Array],
+      images: [Array],
+      icon: [Array],
+      links: [Array]
+    }
+  },
+  url: 'ipfs://QmXJxJePjm6A9TSC4m32GN6h3PknVY2C4HqNaBEF6EeuGB'
+}
+*/
+```
+
 #### Upload Custom LSP4 Metadata Example
 
 ```javascript title="Uploading LSP4Metadata using custom upload options"
@@ -89,7 +127,7 @@ await LSP4DigitalAssetMetadata.uploadMetadata(
       port: 5001,
       protocol: 'https',
     },
-  },
+  }
 );
 /**
 {

--- a/docs/classes/universal-profile.md
+++ b/docs/classes/universal-profile.md
@@ -167,7 +167,7 @@ await lspFactory.UniversalProfile.deploy(
         console.log(contracts);
       },
     },
-  },
+  }
 );
 
 /**
@@ -329,6 +329,12 @@ Object containing the [LSP3 Metadata](../../../standards/universal-profile/lsp3-
 | `links`           | Array         | An Array of Objects containing `title` and `url` parameters.                               |
 | `tags`            | Object        | An object containing the profile data to upload.                                           |
 
+OR
+
+| Name          | Type   | Description                                                                                                    |
+| :------------ | :----- | :------------------------------------------------------------------------------------------------------------- |
+| `LSP3Profile` | Object | Object containing `name`, `description`, `profileImage`, `backgroundImage`, `links`, `tags` as described above |
+
 #### 2. `options` - Object (optional)
 
 Object containing configuration details of how the metadata should be uploaded.
@@ -388,6 +394,33 @@ await UniversalProfile.uploadProfileData({
 */
 ```
 
+```javascript title="Uploading profile data"
+await UniversalProfile.uploadProfileData({
+  LSP3Profile: {
+    name: 'My Universal Profile',
+    description: 'My cool Universal Profile',
+    tags: ['Fashion', 'Design'],
+    links: [{ title: 'My Website', url: 'www.my-website.com' }],
+  },
+});
+
+/**
+{
+  profile: {
+    LSP3Profile: {
+      name: 'My Universal Profile',
+      description: 'My cool Universal Profile',
+      tags: [Array],
+      links: [Array],
+      profileImage: [Array],
+      backgroundImage: [Array]
+    }
+  },
+  url: 'ipfs://QmS7NCnoXub7ju13HZuDzJpWqWq15Nev4CC18821qBNbkx'
+}
+*/
+```
+
 ```javascript title="Uploading profile data using a custom IPFS gateway"
 await UniversalProfile.uploadProfileData(
   {
@@ -416,7 +449,7 @@ await UniversalProfile.uploadProfileData(
   },
   {
     ipfsGateway: 'https://ipfs.infura.io',
-  },
+  }
 );
 
 /**
@@ -450,7 +483,7 @@ await UniversalProfile.uploadProfileData(
       port: 5001,
       protocol: 'https',
     },
-  },
+  }
 );
 
 /**

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -117,7 +117,7 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
     symbol: 'DEMO',
     creators: ['0x7Ab53a0C861fb955050A8DA109eEeA5E61fd8Aa4', '0x6c1F3Ed2F99054C88897e2f32187ef15c62dC560'],
     digitalAssetMetadata: {
-      'description': 'My NFT 2.0'
+      description: 'My NFT 2.0'
       ...
     }
 });
@@ -155,6 +155,23 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
       url: "https://docs.lukso.tech"
     }],
   },
+  ...
+});
+```
+
+LSP4 Metadata can also be passed with the `LSP4Metadata` key:
+
+```javascript title="Passing LSP4Metadata key"
+await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
+  digitalAssetMetadata: {
+    LSP4Metadata: {
+      description: "My Digital Asset",
+      links: [{
+        title: "LUKSO Docs",
+        url: "https://docs.lukso.tech"
+      }],
+    },
+  }
   ...
 });
 ```

--- a/docs/deployment/universal-profile.md
+++ b/docs/deployment/universal-profile.md
@@ -80,6 +80,27 @@ await lspFactory.UniversalProfile.deploy({
 };
 ```
 
+LSP3 Metadata can also be passed with the `LSP3Profile` key:
+
+```javascript title='Uploading an LSP3 metadata automatically'
+await lspFactory.UniversalProfile.deploy({
+    controllerAddresses: ['0x...'],
+    lsp3Profile: {
+      LSP3Profile: {
+        name: 'My-Cool-Profile',
+        description: 'My cool Universal Profile',
+        tags: ['public-profile'],
+        links: [{
+          title: 'My Website',
+          url: 'www.my-website.com'
+        }],
+        ...
+      }
+    }
+  });
+};
+```
+
 The following two examples will download the JSON file before hashing it and generating the proper [JSONURL](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#JSONURL) value.
 
 ```javascript title='Providing a previously uploaded LSP3 metadata IPFS URL'

--- a/src/lib/classes/lsp4-digital-asset-metadata.ts
+++ b/src/lib/classes/lsp4-digital-asset-metadata.ts
@@ -3,6 +3,7 @@ import { ipfsUpload, prepareMetadataAsset, prepareMetadataImage } from '../helpe
 import { LSPFactoryOptions } from '../interfaces';
 import {
   LSP4MetadataBeforeUpload,
+  LSP4MetadataContentBeforeUpload,
   LSP4MetadataUrlForEncoding,
 } from '../interfaces/lsp4-digital-asset';
 import { UploadOptions } from '../interfaces/profile-upload-options';
@@ -15,10 +16,12 @@ export class LSP4DigitalAssetMetadata {
   }
 
   static async uploadMetadata(
-    metaData: LSP4MetadataBeforeUpload,
+    metaData: LSP4MetadataContentBeforeUpload | LSP4MetadataBeforeUpload,
     uploadOptions?: UploadOptions
   ): Promise<LSP4MetadataUrlForEncoding> {
     uploadOptions = uploadOptions || defaultUploadOptions;
+
+    metaData = 'LSP4Metadata' in metaData ? metaData.LSP4Metadata : metaData;
 
     const [images, assets, icon] = await Promise.all([
       metaData.images
@@ -53,7 +56,7 @@ export class LSP4DigitalAssetMetadata {
     };
   }
 
-  async uploadMetadata(metaData: LSP4MetadataBeforeUpload, uploadOptions?: UploadOptions) {
+  async uploadMetadata(metaData: LSP4MetadataContentBeforeUpload, uploadOptions?: UploadOptions) {
     uploadOptions = uploadOptions || this.options.uploadOptions || defaultUploadOptions;
     return LSP4DigitalAssetMetadata.uploadMetadata(metaData, uploadOptions);
   }

--- a/src/lib/classes/lsp7-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp7-digtal-asset.spec.ts
@@ -201,6 +201,7 @@ describe('LSP7DigitalAsset', () => {
 
     const allowedLSP4Formats = [
       lsp4DigitalAsset.LSP4Metadata,
+      lsp4DigitalAsset,
       { json: lsp4DigitalAsset, url: 'ipfs://QmRrqBTQL3h2Vc9PEL3d18VnRknzstEGVCxhVW6jPaZzSF' },
     ];
 

--- a/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
+++ b/src/lib/classes/lsp8-identifiable-digtal-asset.spec.ts
@@ -254,6 +254,7 @@ describe('LSP8IdentifiableDigitalAsset', () => {
 
     const allowedLSP4Formats = [
       lsp4DigitalAsset.LSP4Metadata,
+      lsp4DigitalAsset,
       { json: lsp4DigitalAsset, url: 'ipfs://QmRrqBTQL3h2Vc9PEL3d18VnRknzstEGVCxhVW6jPaZzSF' },
     ];
 

--- a/src/lib/classes/universal-profile.spec.ts
+++ b/src/lib/classes/universal-profile.spec.ts
@@ -50,6 +50,7 @@ describe('UniversalProfile', () => {
 
     const allowedLSP3Formats = [
       lsp3ProfileJson.LSP3Profile,
+      lsp3ProfileJson,
       { json: lsp3ProfileJson, url: 'ipfs://QmbKvCVEePiDKxuouyty9bMsWBAxZDGr2jhxd4pLGLx95D' },
     ];
 

--- a/src/lib/classes/universal-profile.ts
+++ b/src/lib/classes/universal-profile.ts
@@ -12,7 +12,7 @@ import {
   ProfileDataBeforeUpload,
   ProfileDeploymentOptions,
 } from '../interfaces';
-import { ProfileDataForEncoding } from '../interfaces/lsp3-profile';
+import { LSP3ProfileBeforeUpload, ProfileDataForEncoding } from '../interfaces/lsp3-profile';
 import {
   ContractDeploymentOptions,
   DeployedUniversalProfileContracts,
@@ -74,9 +74,16 @@ export class UniversalProfile {
     const deploymentConfiguration =
       convertUniversalProfileConfigurationObject(contractDeploymentOptions);
 
+    const lsp3Profile =
+      typeof profileDeploymentOptions?.lsp3Profile !== 'string' &&
+      typeof profileDeploymentOptions?.lsp3Profile !== 'undefined' &&
+      'LSP3Profile' in profileDeploymentOptions?.lsp3Profile
+        ? profileDeploymentOptions?.lsp3Profile?.LSP3Profile
+        : profileDeploymentOptions?.lsp3Profile;
+
     // -1 > Run IPFS upload process in parallel with contract deployment
     const lsp3Profile$ = lsp3ProfileUpload$(
-      profileDeploymentOptions.lsp3Profile,
+      lsp3Profile,
       deploymentConfiguration?.uploadOptions ?? this.options.uploadOptions
     );
 
@@ -212,10 +219,12 @@ export class UniversalProfile {
    * @memberof UniversalProfile
    */
   static async uploadProfileData(
-    profileData: ProfileDataBeforeUpload,
+    profileData: ProfileDataBeforeUpload | LSP3ProfileBeforeUpload,
     uploadOptions?: UploadOptions
   ): Promise<ProfileDataForEncoding> {
     uploadOptions = uploadOptions || defaultUploadOptions;
+
+    profileData = 'LSP3Profile' in profileData ? profileData.LSP3Profile : profileData;
 
     const [profileImage, backgroundImage, avatar] = await Promise.all([
       prepareMetadataImage(uploadOptions, profileData.profileImage),

--- a/src/lib/interfaces/digital-asset-deployment.ts
+++ b/src/lib/interfaces/digital-asset-deployment.ts
@@ -1,4 +1,8 @@
-import { LSP4MetadataBeforeUpload, LSP4MetadataForEncoding } from './lsp4-digital-asset';
+import {
+  LSP4MetadataBeforeUpload,
+  LSP4MetadataContentBeforeUpload,
+  LSP4MetadataForEncoding,
+} from './lsp4-digital-asset';
 import { IPFSGateway, UploadOptions } from './profile-upload-options';
 
 import { ContractOptions, DeployedContract, DeploymentEventCallbacks } from '.';
@@ -12,7 +16,11 @@ export interface DigitalAssetDeploymentOptions {
   controllerAddress: string;
   name: string;
   symbol: string;
-  digitalAssetMetadata?: LSP4MetadataBeforeUpload | LSP4MetadataForEncoding | string;
+  digitalAssetMetadata?:
+    | LSP4MetadataBeforeUpload
+    | LSP4MetadataContentBeforeUpload
+    | LSP4MetadataForEncoding
+    | string;
   creators?: string[];
 }
 

--- a/src/lib/interfaces/lsp3-profile.ts
+++ b/src/lib/interfaces/lsp3-profile.ts
@@ -37,6 +37,10 @@ export interface ProfileDataBeforeUpload {
   avatar?: (File | AssetMetadata)[];
 }
 
+export interface LSP3ProfileBeforeUpload {
+  LSP3Profile: ProfileDataBeforeUpload;
+}
+
 export interface ProfileDataForEncoding {
   json: LSP3ProfileJSON;
   url: string;

--- a/src/lib/interfaces/lsp4-digital-asset.ts
+++ b/src/lib/interfaces/lsp4-digital-asset.ts
@@ -12,12 +12,16 @@ export interface LSP4DigitalAsset {
   icon: ImageMetadata[];
 }
 
-export interface LSP4MetadataBeforeUpload {
+export interface LSP4MetadataContentBeforeUpload {
   description: string;
   links?: LinkMetdata[];
   icon?: File | ImageBuffer | ImageMetadata[];
   images?: (File | ImageBuffer | ImageMetadata[])[];
   assets?: (File | AssetBuffer | AssetMetadata)[];
+}
+
+export interface LSP4MetadataBeforeUpload {
+  LSP4Metadata: LSP4MetadataContentBeforeUpload;
 }
 
 export interface LSP4MetadataUrlForEncoding {

--- a/src/lib/interfaces/profile-deployment.ts
+++ b/src/lib/interfaces/profile-deployment.ts
@@ -1,6 +1,10 @@
 import { ContractOptions, DeployedContract } from '../..';
 
-import { LSP3ProfileDataForEncoding, ProfileDataBeforeUpload } from './lsp3-profile';
+import {
+  LSP3ProfileBeforeUpload,
+  LSP3ProfileDataForEncoding,
+  ProfileDataBeforeUpload,
+} from './lsp3-profile';
 import { IPFSGateway, UploadOptions } from './profile-upload-options';
 
 import { DeploymentEventCallbacks } from '.';
@@ -21,7 +25,11 @@ export interface ControllerOptions {
  */
 export interface ProfileDeploymentOptions {
   controllerAddresses: (string | ControllerOptions)[];
-  lsp3Profile?: ProfileDataBeforeUpload | LSP3ProfileDataForEncoding | string;
+  lsp3Profile?:
+    | ProfileDataBeforeUpload
+    | LSP3ProfileBeforeUpload
+    | LSP3ProfileDataForEncoding
+    | string;
 }
 
 export interface DeployedUniversalProfileContracts {

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -56,6 +56,7 @@ import {
 import {
   LSP4DigitalAssetJSON,
   LSP4MetadataBeforeUpload,
+  LSP4MetadataContentBeforeUpload,
   LSP4MetadataForEncoding,
   LSP4MetadataUrlForEncoding,
 } from '../interfaces/lsp4-digital-asset';
@@ -348,10 +349,21 @@ function initializeLSP8Proxy(
 }
 
 export function lsp4MetadataUpload$(
-  lsp4Metadata: LSP4MetadataBeforeUpload | LSP4MetadataForEncoding | string,
+  passedDigitalAssetMetadata:
+    | LSP4MetadataBeforeUpload
+    | LSP4MetadataContentBeforeUpload
+    | LSP4MetadataForEncoding
+    | string,
   uploadOptions?: UploadOptions
 ) {
   let lsp4Metadata$: Observable<string>;
+
+  const lsp4Metadata =
+    typeof passedDigitalAssetMetadata !== 'string' &&
+    typeof passedDigitalAssetMetadata !== 'undefined' &&
+    'LSP4Metadata' in passedDigitalAssetMetadata
+      ? passedDigitalAssetMetadata.LSP4Metadata
+      : passedDigitalAssetMetadata;
 
   if (typeof lsp4Metadata !== 'string' || !isMetadataEncoded(lsp4Metadata)) {
     lsp4Metadata$ = lsp4Metadata
@@ -365,7 +377,7 @@ export function lsp4MetadataUpload$(
 }
 
 export async function getLSP4MetadataUrl(
-  lsp4Metadata: LSP4MetadataBeforeUpload | string,
+  lsp4Metadata: LSP4MetadataContentBeforeUpload | string,
   uploadOptions: UploadOptions
 ): Promise<LSP4MetadataUrlForEncoding> {
   let lsp4MetadataForEncoding: LSP4MetadataUrlForEncoding;
@@ -396,7 +408,7 @@ export async function getLSP4MetadataUrl(
 }
 
 export async function getEncodedLSP4Metadata(
-  lsp4Metadata: LSP4MetadataBeforeUpload | LSP4MetadataForEncoding | string,
+  lsp4Metadata: LSP4MetadataContentBeforeUpload | LSP4MetadataForEncoding | string,
   uploadOptions: UploadOptions
 ): Promise<string> {
   let lsp4MetadataForEncoding: LSP4MetadataForEncoding;

--- a/src/lib/services/universal-profile.service.ts
+++ b/src/lib/services/universal-profile.service.ts
@@ -37,7 +37,11 @@ import {
   ProfileDataBeforeUpload,
   UniversalProfileDeploymentConfiguration,
 } from '../interfaces';
-import { LSP3ProfileDataForEncoding, ProfileDataForEncoding } from '../interfaces/lsp3-profile';
+import {
+  LSP3ProfileBeforeUpload,
+  LSP3ProfileDataForEncoding,
+  ProfileDataForEncoding,
+} from '../interfaces/lsp3-profile';
 import { UploadOptions } from '../interfaces/profile-upload-options';
 
 import { UniversalReveiverDeploymentEvent } from './universal-receiver.service';
@@ -318,10 +322,21 @@ async function getEncodedLSP3ProfileData(
 }
 
 export function lsp3ProfileUpload$(
-  lsp3Profile: ProfileDataBeforeUpload | LSP3ProfileDataForEncoding | string,
+  passedProfileData:
+    | ProfileDataBeforeUpload
+    | LSP3ProfileBeforeUpload
+    | LSP3ProfileDataForEncoding
+    | string,
   uploadOptions?: UploadOptions
 ) {
   let lsp3Profile$: Observable<string>;
+
+  const lsp3Profile =
+    typeof passedProfileData !== 'string' &&
+    typeof passedProfileData !== 'undefined' &&
+    'LSP3Profile' in passedProfileData
+      ? passedProfileData?.LSP3Profile
+      : passedProfileData;
 
   if (typeof lsp3Profile !== 'string' || !isMetadataEncoded(lsp3Profile)) {
     lsp3Profile$ = lsp3Profile


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Improvement

Allow passing metadata with `LSP3Profile` or `LSP4Metadata` key.

```javascript
await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
  digitalAssetMetadata: {
    LSP4Metadata: {
      description: "My Digital Asset",
      ...
    },
  }
  ...
});
```

Updates docs