### PR TITLE
fix: remove gas price from gas estimates

### DIFF
--- a/src/lib/helpers/deployment.helper.ts
+++ b/src/lib/helpers/deployment.helper.ts
@@ -76,9 +76,7 @@ export function initialize(
     switchMap(async (result) => {
       const contract = await factory.attach(result.receipt.contractAddress);
       const initializeParams = await initArguments(result);
-      const gasEstimate = await contract.estimateGas.initialize(...initializeParams, {
-        gasPrice: GAS_PRICE,
-      });
+      const gasEstimate = await contract.estimateGas.initialize(...initializeParams);
       const transaction = await contract.initialize(...initializeParams, {
         gasLimit: gasEstimate.add(GAS_BUFFER),
         gasPrice: GAS_PRICE,

--- a/src/lib/services/digital-asset.service.ts
+++ b/src/lib/services/digital-asset.service.ts
@@ -176,10 +176,7 @@ function initializeLSP7Proxy(
         name,
         symbol,
         controllerAddress,
-        isNFT,
-        {
-          gasPrice: GAS_PRICE,
-        }
+        isNFT
       );
 
       const transaction = await contract[`initialize(string,string,address,bool)`](
@@ -321,10 +318,7 @@ function initializeLSP8Proxy(
       const gasEstimate = await contract.estimateGas[`initialize(string,string,address)`](
         name,
         symbol,
-        controllerAddress,
-        {
-          gasPrice: GAS_PRICE,
-        }
+        controllerAddress
       );
 
       const transaction = await contract[`initialize(string,string,address)`](
@@ -520,10 +514,7 @@ export async function sendSetDataAndTransferOwnershipTransactions(
   if (keysToSet && valuesToSet) {
     const setDataEstimate = await digitalAsset.estimateGas['setData(bytes32[],bytes[])'](
       keysToSet,
-      valuesToSet,
-      {
-        gasPrice: GAS_PRICE,
-      }
+      valuesToSet
     );
 
     setDataTransaction = digitalAsset['setData(bytes32[],bytes[])'](keysToSet, valuesToSet, {
@@ -545,7 +536,6 @@ export async function sendSetDataAndTransferOwnershipTransactions(
       controllerAddress,
       {
         from: signerAddress,
-        gasPrice: GAS_PRICE,
       }
     );
 

--- a/src/lib/services/universal-profile.service.ts
+++ b/src/lib/services/universal-profile.service.ts
@@ -485,17 +485,13 @@ export async function sendSetDataAndTransferOwnershipTransactions(
 
   const setDataEstimate = await erc725Account.estimateGas['setData(bytes32[],bytes[])'](
     keysToSet,
-    valuesToSet as BytesLike[],
-    {
-      gasPrice: GAS_PRICE,
-    }
+    valuesToSet as BytesLike[]
   );
 
   const transferOwnershipEstimate = await erc725Account.estimateGas.transferOwnership(
     keyManagerAddress,
     {
       from: signerAddress,
-      gasPrice: GAS_PRICE,
     }
   );
 
@@ -547,7 +543,6 @@ export async function claimOwnership(
 
   const claimOwnershipEstimate = await keyManager.estimateGas.execute(claimOwnershipPayload, {
     from: signerAddress,
-    gasPrice: GAS_PRICE,
   });
 
   const claimOwnershipTransaction = await keyManager.execute(claimOwnershipPayload, {
@@ -601,7 +596,6 @@ export async function revokeSignerPermissions(
     revokeSignerPermissionsPayload,
     {
       from: signerAddress,
-      gasPrice: GAS_PRICE,
     }
   );
 


### PR DESCRIPTION
Fix

Removes gas price when estimating gas. When passing gas price in the RPC call to eth node the request does not go through, the applies to the geth version used on l16 but not l14
