### PR TITLE
chore: add missing type for instance uploadMetadata

### DIFF
--- a/src/lib/classes/lsp4-digital-asset-metadata.ts
+++ b/src/lib/classes/lsp4-digital-asset-metadata.ts
@@ -56,7 +56,10 @@ export class LSP4DigitalAssetMetadata {
     };
   }
 
-  async uploadMetadata(metaData: LSP4MetadataContentBeforeUpload, uploadOptions?: UploadOptions) {
+  async uploadMetadata(
+    metaData: LSP4MetadataContentBeforeUpload | LSP4MetadataBeforeUpload,
+    uploadOptions?: UploadOptions
+  ) {
     uploadOptions = uploadOptions || this.options.uploadOptions || defaultUploadOptions;
     return LSP4DigitalAssetMetadata.uploadMetadata(metaData, uploadOptions);
   }


### PR DESCRIPTION
Adds missing type to allow passing LSP4 metadata with LSP4Metadata key to `uploadMetadata`. This was available on static version of the method but not missing from instance method