### PR TITLE
Change `isNFT` to `isNonDivisible`

### DIFF
--- a/docs/classes/lsp7-digital-asset.md
+++ b/docs/classes/lsp7-digital-asset.md
@@ -30,7 +30,7 @@ Specify properties to be set on the LSP7 Digital Asset during deployment.
 | [`name`](../deployment/digital-asset#digital-asset-properties)                          | String           | The name of the token. Passed to the LSP7 smart contract as a constructor parameter                                                              |
 | [`symbol`](../deployment/digital-asset#digital-asset-properties)                        | String           | The symbol of the token. Passed to the LSP7 smart contract as a constructor parameter                                                            |
 | [`controllerAddress`](../deployment/digital-asset#controller-address)                   | String           | The owner of the contract. Passed to the LSP7 smart contract constructor parameter                                                               |
-| [`isNFT`](../deployment/digital-asset#lsp7-nft-20)                                      | Boolean          | Specify if the token should be fungible by setting the [LSP7 decimals] value to 18. Passed to the LSP7 smart contract as a constructor parameter |
+| [`isNonDivisible`](../deployment/digital-asset#lsp7-nft-20)                                      | Boolean          | Specify if the token should be fungible by setting the [LSP7 decimals] value to 18. Passed to the LSP7 smart contract as a constructor parameter |
 | [`digitalAssetMetadata`](../deployment/digital-asset#digital-asset-metadata) (optional) | Object \| String | The [LSP4] metadata to be attached to the smart contract.                                                                                        |
 | [`creators`](../deployment/digital-asset#adding-lsp4-metadata) (optional)               | Array            | The [LSP4] metadata to be attached to the smart contract.                                                                                        |
 
@@ -61,7 +61,7 @@ await lspFactory.LSP7DigitalAsset.deploy({
   name: 'My token',
   symbol: 'TKN',
   controllerAddress: '0xb74a88C43BCf691bd7A851f6603cb1868f6fc147',
-  isNFT: true,
+  isNonDivisible: true,
 });
 /**
 {
@@ -98,7 +98,7 @@ await lspFactory.LSP7DigitalAsset.deploy(
     name: 'My token',
     symbol: 'TKN',
     controllerAddress: '0xb74a88C43BCf691bd7A851f6603cb1868f6fc147',
-    isNFT: true,
+    isNonDivisible: true,
   },
   {
     onDeployEvents: {

--- a/docs/deployment/digital-asset.md
+++ b/docs/deployment/digital-asset.md
@@ -32,11 +32,11 @@ The [LSP7](./digital-asset.md#lsp7-nft-20) and [LSP8](./digital-asset.md#lsp8-nf
 
 The [LSP7] standard can be useful for NFT collections where you want all tokens to have the same [metadata](./digital-asset.md#adding-lsp4-metadata). For example a collection of digital clothing items.
 
-[LSP7] is based on the [ERC20] token standard and can be used as an NFT 2.0 contract by setting the `isNFT` constructor value to `true` when deploying. This will set the contract [decimals](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-7-DigitalAsset.md#decimals) value to 0 so that all tokens are indivisible.
+[LSP7] is based on the [ERC20] token standard and can be used as an NFT 2.0 contract by setting the `isNonDivisible` constructor value to `true` when deploying. This will set the contract [decimals](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-7-DigitalAsset.md#decimals) value to 0 so that all tokens are indivisible.
 
 ```javascript
 await lspFactory.LSP7DigitalAsset.deploy({
-    isNFT: true,
+    isNonDivisible: true,
     controllerAddress: '0x56fE4E7dc2bc0b6397E4609B07b4293482E3F72B',
     name: 'MYTOKEN'
     symbol: 'DEMO',
@@ -44,7 +44,7 @@ await lspFactory.LSP7DigitalAsset.deploy({
 ```
 
 :::info
-To deploy an [LSP7] NFT 2.0 smart contract, the `isNFT` parameter must be set to `true` when deploying. If `isNFT` is set to false the token decimals value will be set to 18 meaning they can be fractionalized.
+To deploy an [LSP7] NFT 2.0 smart contract, the `isNonDivisible` parameter must be set to `true` when deploying. If `isNonDivisible` is set to false the token decimals value will be set to 18 meaning they can be fractionalized.
 :::
 
 #### LSP8 NFT 2.0
@@ -71,24 +71,24 @@ await lspFactory.LSP7DigitalAsset.deploy(digitalAssetProperties [, options]);
 
 ```javascript
 await lspFactory.LSP7DigitalAsset.deploy({
-    isNFT: false,
+    isNonDivisible: false,
     controllerAddress: '0x56fE4E7dc2bc0b6397E4609B07b4293482E3F72B',
     name: 'MYTOKEN'
     symbol: 'DEMO',
 });
 ```
 
-When deploying, set the `isNFT` value to `false`. This will set the [decimals](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-7-DigitalAsset.md#decimals) value on the token contract to 18, allowing tokens to be fractionalized.
+When deploying, set the `isNonDivisible` value to `false`. This will set the [decimals](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-7-DigitalAsset.md#decimals) value on the token contract to 18, allowing tokens to be fractionalized.
 
 ## Digital Asset Properties
 
 Inside the `digitalAssetProperties` object, you can set digital assset configuration options such as the [controller address](./digital-asset.md#controller-address) and [LSP4 metadata](./digital-asset.md#adding-lsp4-metadata).
 
-[LSP7] and [LSP8] share the same constructor parameters, however LSP7 has an additional parameter `isNFT` used to set the decimals value on the contract to 0 or 18.
+[LSP7] and [LSP8] share the same constructor parameters, however LSP7 has an additional parameter `isNonDivisible` used to set the decimals value on the contract to 0 or 18.
 
 ```javascript
 await lspFactory.LSP7DigitalAsset.deploy({
-    isNFT: false,
+    isNonDivisible: false,
     controllerAddress: '0x56fE4E7dc2bc0b6397E4609B07b4293482E3F72B',
     name: 'MYTOKEN'
     symbol: 'DEMO',
@@ -104,7 +104,7 @@ await lspFactory.LSP8IdentifiableDigitalAsset.deploy({
 ```
 
 :::info
-use the `isNFT` parameter on [LSP7] to deploy an [NFT 2.0](./digital-asset.md#deploying-an-nft-20) or [token contract](./digital-asset.md#deploying-a-fungible-token).
+use the `isNonDivisible` parameter on [LSP7] to deploy an [NFT 2.0](./digital-asset.md#deploying-an-nft-20) or [token contract](./digital-asset.md#deploying-a-fungible-token).
 :::
 
 ### Controller Address


### PR DESCRIPTION
Assuming that LSP7 is for tokens like ERC20, not NFT like LSP8 it might be confusing in sense that some might think that setting isNFT to true would create an NFT, which is not entirely true. In this sense the param should be rather called isNonDivisible.
