### PR TITLE
fix: Remove custom ipfs gatway from integration tests

### DIFF
--- a/src/lib/classes/universal-profile.spec.ts
+++ b/src/lib/classes/universal-profile.spec.ts
@@ -77,47 +77,6 @@ describe('UniversalProfile', () => {
       });
     });
   });
-  describe('Deploying with LSP3Profile Metadata with specified IPFS client options', () => {
-    const allowedIPFSGatewayFormats = [
-      { host: 'ipfs.infura.io', port: 5001, protocol: 'https' },
-      'https://ipfs.infura.io:5001',
-      'https://ipfs.infura.io',
-    ];
-
-    allowedIPFSGatewayFormats.forEach((allowedGatewayFormat) => {
-      let signer;
-      let universalProfile: UniversalProfile;
-      let keyManager;
-
-      beforeAll(async () => {
-        signer = signers[0];
-
-        const { LSP0ERC725Account, LSP6KeyManager } = await lspFactory.UniversalProfile.deploy(
-          {
-            controllerAddresses: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-            lsp3Profile: lsp3ProfileJson.LSP3Profile,
-          },
-          {
-            ipfsGateway: allowedGatewayFormat,
-          }
-        );
-
-        universalProfile = UniversalProfile__factory.connect(LSP0ERC725Account.address, signer);
-        keyManager = LSP6KeyManager;
-      });
-
-      it('should deploy and set LSP3Profile data', async () => {
-        const ownerAddress = await universalProfile.owner();
-        expect(ownerAddress).toEqual(keyManager.address);
-
-        const data = await universalProfile['getData(bytes32[])']([
-          '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-        ]);
-
-        expect(data[0].startsWith('0x6f357c6a')).toBe(true);
-      });
-    });
-  });
 
   describe('Deploying a UP with one controller address', () => {
     let uniqueController: SignerWithAddress;


### PR DESCRIPTION
Remove custom ipfs gatway tests from integration tests.

Infura removed their public gateway so we can no longer use this in these tests. 

Custom ipfs gateway is already tested in upload-helper.spec.ts so we can remove these tests