### PR TITLE
fix: typo in `LinkMetadata` interface

### DIFF
--- a/src/lib/interfaces/index.ts
+++ b/src/lib/interfaces/index.ts
@@ -1,7 +1,7 @@
 export { ContractOptions } from './contract-options';
 export { LSPFactoryOptions } from './lsp-factory-options';
 export { LSP3Profile, LSP3ProfileJSON, ProfileDataBeforeUpload } from './lsp3-profile';
-export { ImageMetadata, LinkMetdata, ImageBuffer, SupportedImageBufferFormats } from './metadata';
+export { ImageMetadata, LinkMetadata, ImageBuffer, SupportedImageBufferFormats } from './metadata';
 
 export * from './profile-deployment';
 export * from './deployment-events';

--- a/src/lib/interfaces/lsp3-profile.ts
+++ b/src/lib/interfaces/lsp3-profile.ts
@@ -1,4 +1,4 @@
-import { AssetMetadata, ImageBuffer, ImageMetadata, LinkMetdata } from './metadata';
+import { AssetMetadata, ImageBuffer, ImageMetadata, LinkMetadata } from './metadata';
 
 export interface LSP3ProfileJSON {
   LSP3Profile: LSP3Profile;
@@ -10,7 +10,7 @@ export interface LSP3Profile {
   profileImage?: ImageMetadata[];
   backgroundImage?: ImageMetadata[];
   tags?: string[];
-  links?: LinkMetdata[];
+  links?: LinkMetadata[];
   avatar?: AssetMetadata[];
 }
 
@@ -32,7 +32,7 @@ export interface ProfileDataBeforeUpload {
   backgroundImage?: File | ImageBuffer | ImageMetadata[];
   name: string;
   description: string;
-  links?: LinkMetdata[];
+  links?: LinkMetadata[];
   tags?: string[];
   avatar?: (File | AssetMetadata)[];
 }

--- a/src/lib/interfaces/lsp4-digital-asset.ts
+++ b/src/lib/interfaces/lsp4-digital-asset.ts
@@ -1,4 +1,4 @@
-import { AssetBuffer, AssetMetadata, ImageBuffer, ImageMetadata, LinkMetdata } from './metadata';
+import { AssetBuffer, AssetMetadata, ImageBuffer, ImageMetadata, LinkMetadata } from './metadata';
 
 export interface LSP4DigitalAssetJSON {
   LSP4Metadata: LSP4DigitalAsset;
@@ -6,7 +6,7 @@ export interface LSP4DigitalAssetJSON {
 
 export interface LSP4DigitalAsset {
   description: string;
-  links: LinkMetdata[];
+  links: LinkMetadata[];
   images: ImageMetadata[][];
   assets: AssetMetadata[];
   icon: ImageMetadata[];
@@ -14,7 +14,7 @@ export interface LSP4DigitalAsset {
 
 export interface LSP4MetadataContentBeforeUpload {
   description: string;
-  links?: LinkMetdata[];
+  links?: LinkMetadata[];
   icon?: File | ImageBuffer | ImageMetadata[];
   images?: (File | ImageBuffer | ImageMetadata[])[];
   assets?: (File | AssetBuffer | AssetMetadata)[];

--- a/src/lib/interfaces/metadata.ts
+++ b/src/lib/interfaces/metadata.ts
@@ -6,7 +6,7 @@ export interface ImageMetadata {
   url: string;
 }
 
-export interface LinkMetdata {
+export interface LinkMetadata {
   title: string;
   url: string;
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Fixes typo in `LinkMetadata` interface.
