### PR TITLE
improvement: fix deployments from a Universal Profile Signer

### DIFF
--- a/src/lib/classes/lsp7-digital-asset.ts
+++ b/src/lib/classes/lsp7-digital-asset.ts
@@ -101,14 +101,15 @@ export class LSP7DigitalAsset {
       digitalAssetConfiguration?.byteCode
     );
 
+    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
+
     const digitalAsset$ = lsp7DigitalAssetDeployment$(
       this.signer,
       digitalAssetDeploymentOptions,
       baseContractAddress$,
+      signerIsUniversalProfile$,
       digitalAssetConfiguration?.byteCode
     );
-
-    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
 
     const setLSP4AndTransferOwnership$ = setMetadataAndTransferOwnership$(
       this.signer,

--- a/src/lib/classes/lsp8-identifiable-digital-asset.ts
+++ b/src/lib/classes/lsp8-identifiable-digital-asset.ts
@@ -100,14 +100,15 @@ export class LSP8IdentifiableDigitalAsset {
       digitalAssetConfiguration?.byteCode
     );
 
+    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
+
     const digitalAsset$ = lsp8IdentifiableDigitalAssetDeployment$(
       this.signer,
       digitalAssetDeploymentOptions,
+      signerIsUniversalProfile$,
       baseContractAddress$,
       digitalAssetConfiguration?.byteCode
     );
-
-    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
 
     const setLSP4AndTransferOwnership$ = setMetadataAndTransferOwnership$(
       this.signer,

--- a/src/lib/classes/universal-profile.ts
+++ b/src/lib/classes/universal-profile.ts
@@ -126,14 +126,15 @@ export class UniversalProfile {
       deployUniversalReceiverProxy
     );
 
+    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
+
     // 1 > deploys ERC725Account
     const account$ = accountDeployment$(
       this.signer,
       baseContractAddresses$,
+      signerIsUniversalProfile$,
       deploymentConfiguration?.LSP0ERC725Account?.byteCode
     );
-
-    const signerIsUniversalProfile$ = isSignerUniversalProfile$(this.signer);
 
     // 2 > deploys KeyManager
     const keyManager$ = keyManagerDeployment$(


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Fix

Fixes bugs when using Universal Profile browser extension to deploy assets/profiles

Works when sending from a UP using executeRelayCall execution. Unable to test sending from a UP with controller address