### PR TITLE
fix: give permission `REENTRANCY` to LSP1Delegate

### DIFF
--- a/src/lib/services/universal-profile.service.ts
+++ b/src/lib/services/universal-profile.service.ts
@@ -439,7 +439,7 @@ export async function prepareSetDataParameters(
 
   const valuesToSet = [
     universalReceiverDelegateAddress,
-    ERC725.encodePermissions({ SUPER_SETDATA: true }),
+    ERC725.encodePermissions({ SUPER_SETDATA: true, REENTRANCY: true }),
     ethers.utils.defaultAbiCoder.encode(['uint256'], [controllerPermissions.length + 1]),
     ...controllerAddresses,
     ...controllerPermissions,


### PR DESCRIPTION
The LSP1Delegate is not given the permission `REENTRANCY` on the UP being deployed.

Fixed this by adding the missing permission when setting the permissions.
