### PR TITLE
ci: add release please workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,25 @@
-name: Release package
+name: Create GitHub release and publish to NPM
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - 'main'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  release:
-    name: 📦 Create GitHub release and publish to NPM
+  release-please:
+    name: release
     runs-on: ubuntu-latest
 
     steps:
-      - name: Ensure main branch
-        if: github.ref != 'refs/heads/main'
-        run: |-
-          echo "Not running on main - exit"
-          exit 1
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 16.x
+      - name: ⚙️ Setup Node.js v16
         uses: actions/setup-node@v2
         with:
           node-version: '16.x'
@@ -30,71 +27,35 @@ jobs:
           scope: '@lukso'
           cache: 'npm'
 
+      - name: 🧰 Install
+        run: npm ci
+
+      - name: 💅 Lint
+        run: npm run lint
+
+      - name: 🎯 Test
+        run: npm test
+
+      - name: 🛠 Build
+        run: npm run build
+
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: '@lukso/lsp-factory.js'
+          bump-minor-pre-major: true
+          default-branch: main
+
       - name: 🔍 Check if version changed
         uses: EndBug/version-check@v1
         if: github.event_name == 'push'
         id: check
 
       - name: 🔄 Check if should release
-        run: echo "SHOULD_RELEASE=${{ steps.check.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' }}" >> $GITHUB_ENV
+        run: echo "SHOULD_RELEASE=${{ steps.check.outputs.changed == 'true' }}" >> $GITHUB_ENV
 
-      - name: 📝 Set Version
-        if: env.SHOULD_RELEASE == 'true'
-        run: |-
-          APP_VERSION="v$(node -pe "require('./package.json').version")"
-          echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
-
-      - name: 🧰 Install
-        if: env.SHOULD_RELEASE == 'true'
-        run: npm ci
-
-      - name: 🧹 Lint
-        if: env.SHOULD_RELEASE == 'true'
-        run: npm run lint
-
-      - name: 🛠 Build
-        if: env.SHOULD_RELEASE == 'true'
-        run: npm run build
-
-      - name: 🎯 Test
-        if: env.SHOULD_RELEASE == 'true'
-        run: npm run generate-types && npm run test
-
-      # We assume this will be always triggered by a merge from develop
-      # Therefore we tag the previous commit (the merge commit won't be on develop)
-      - name: 🏷 Create and push Git Tag
-        if: env.SHOULD_RELEASE == 'true'
-        run: |-
-          git config --global user.email "release@lukso.network"
-          git config --global user.name "LUKSO Bot"
-          git tag -a ${{ env.APP_VERSION }} HEAD~ -m "Release Version ${{ env.APP_VERSION }} [CI]"
-          git push --set-upstream origin tag ${{ env.APP_VERSION }}
-
-      # Create GitHub Release
-      - name: 📝 Extract release notes from CHANGELOG
-        if: env.SHOULD_RELEASE == 'true'
-        id: extract-release-notes
-        uses: ffurrer2/extract-release-notes@v1
-        with:
-          release_notes_file: RELEASENOTES.md
-
-      - name: Add PR body to Release Notes
-        if: env.SHOULD_RELEASE == 'true'
-        env:
-          PR_BODY: ${{ steps.findPR.outputs.body }}
-        run: |-
-          echo ${PR_BODY}|cat - RELEASENOTES.md > /tmp/out && mv /tmp/out RELEASENOTES.md
-
-      - name: 🚀 Create GitHub release
-        if: env.SHOULD_RELEASE == 'true'
-        uses: ncipollo/release-action@v1
-        with:
-          bodyFile: 'RELEASENOTES.md'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.APP_VERSION }}
-
-      # Publish to NPM
-      - name: Publish
+      - name: 📦 Publish to NPM
         if: env.SHOULD_RELEASE == 'true'
         run: npm publish --access public
         env:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,63 +1,63 @@
 # Release Process
 
-Releases are published to NPM when `develop` is merged into `main` AND when the merged code contains a version bump in the `package.json`.
+Releases are published to npm using [Release Please](https://github.com/googleapis/release-please).
 
-## Create and publish a new release:
+This package automates CHANGELOG generation, version bumps and npm releases by parsing the
+git history, looking for [Conventional Commit messages](https://www.conventionalcommits.org/).
 
-### Bump version
+When changes and feature PRs are merged from develop to main, `release-please` will open and maintain a release PR with the updated CHANGELOG and new version number. When this PR is merged, a release will be created and the package published to NPM.
 
-1. Checkout to a new version bump branch from `develop`.
+1. Merge develop into main.
+2. Release Please will create the release PR going to main.
+3. Merge the generated release PR.
+4. Package will be published to NPM.
 
-```bash
-git checkout develop
-git checkout -b bump-vX.X.X
+## Conventional Commit prefixes?
+
+Commits should follow the [Conventional Commit messages standard](https://www.conventionalcommits.org/).
+
+The following commit prefixes will result in changes in the CHANGELOG:
+
+- `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/)
+  patch.
+- `feat:` which represents a new feature, and correlates to a minor version increase.
+  (indicated by the `!`) and will result in a SemVer major version increase.
+- `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change
+- `build:` Changes that affect the build system or external dependencies.
+- `ci:` Changes to our CI configuration files and scripts.
+- `docs:` Documentation only changes.
+- `perf:` A code change that improves performance.
+- `refactor:` A code change that neither fixes a bug nor adds a feature.
+- `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
+- `test:` Adding missing tests or correcting existing tests.
+- `chore:` Other
+
+## Release with a custom version number
+
+When a commit to the main branch has `Release-As: x.x.x` (case insensitive) in the **commit body**, Release Please will open a new pull request for the specified version.
+
+`git commit --allow-empty -m "chore: release 2.0.0" -m "Release-As: 2.0.0"` results in the following commit message:
+
+```txt
+chore: release 2.0.0
+
+Release-As: 2.0.0
 ```
 
-2. Bump version with [standard-version](https://github.com/conventional-changelog/standard-version). This will automatically increase the version number and release notes and commit the changes in a release commit. To create specific versions such as a prerelease version, see below.
+## How can I fix release notes?
 
-```bash
-npm run version
+If you have merged a pull request and would like to amend the commit message
+used to generate the release notes for that commit, you can edit the body of
+the merged pull requests and add a section like:
+
+```
+BEGIN_COMMIT_OVERRIDE
+feat: add ability to override merged commit message
+
+fix: another message
+chore: a third message
+END_COMMIT_OVERRIDE
 ```
 
-3. Push the changes to origin. A git tag is created by the release CI so do **not** push tags here.
-
-```bash
-git push origin
-```
-
-4. Open a PR from your version bump branch to `develop` and merge it.
-
-### Release
-
-- Create and merge a PR from `develop` into `main`.
-- The CI will create a GitHub release and publish to NPM when it detects a merge to main that includes an increase in the `package.json` file.
-
-If it fails, you can manually trigger the workflow from the [Actions](https://github.com/ERC725Alliance/erc725.js/actions/workflows/release.yml) tab.
-
-## Specific Version Increases
-
-To ignore the automatic version increase in favour of a custom version use the `--release-as` flag with the argument `major`, `minor` or `patch` or a specific version number:
-
-```bash
-npm run release -- --release-as minor
-# Or
-npm run release -- --release-as 1.1.0
-```
-
-## Prerelease versions
-
-To create a pre-release run:
-
-```bash
-npm run release -- --prerelease
-```
-
-If the lastest version is 1.0.0, the pre-release command will change the version to: `1.0.1-0`
-
-To name the pre-release, set the name by adding `--prerelease <name>`
-
-```bash
-npm run release -- --prerelease alpha
-```
-
-If the latest version is 1.0.0 this will change the version to: `1.0.1-alpha.0`
+The next time Release Please runs, it will use that override section as the
+commit message instead of the merged commit message.


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
CI

### What is the current behaviour (you can also link to an open issue here)?
Current release CI is broken and requires manually editing CHANGELOG

### What is the new behaviour (if this is a feature change)?
1. Merge develop into main.
2. Release Please will create the release PR going to main.
3. Merge the generated release PR.
4. Package will be published to NPM.

### Other information:
the first time a new release is run the CHANGELOG will still need to be manually updated, this is because the way the previous CI did things broke the CHANGELOG for the _next_ release. After this the CHANGELOG should be running correctly again