### PR TITLE
Fix source map

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-types/ethers-v5
 test/
 
 cache

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "CHANGELOG.md",
     "LICENSE",
     "CONTRIBUTING.md",
-    "README.md"
+    "README.md",
+    "src/*",
+    "types/*"
   ],
   "ava": {
     "failFast": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
     "moduleResolution": "node",
     "module": "commonjs",
     "declaration": true,
-    "inlineSourceMap": false,
-    "sourceMap": true,
+    "inlineSourceMap": true,
+    "sourceMap": false,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "resolveJsonModule": true /* Include modules imported with .json extension. */,
 

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es2015",
     "outDir": "build/module",
-    "module": "es2015"
+    "module": "es2015",
+    "inlineSourceMap": true
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
This PR introduce source map.

### What is the current behaviour (you can also link to an open issue here)?
When on a dapp an issue comes from the lsp-factory library, it s not possible to have a look at the typescript file of the library.

### What is the new behaviour (if this is a feature change)?
We can access the typescript file of the library from the browser of the dapp.

<img width="1728" alt="image" src="https://github.com/lukso-network/tools-lsp-factory/assets/51906903/53eaf78a-cfcf-4709-850f-5f8345e0e810">


### Other information:

It was a real concern for me that activating inline source map increases the weight of the library 
(From 990kB to 1.2 MB) as we want our library to be as light as possible.

On this topic Andrea said that
"There is currently really no other way. Normally the consumer of the library should just be able to work with the source code if we had a real language". 