### PR TITLE
Update main branch with latest docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install @lukso/lsp-factory.js
 ```javascript
 import { LSPFactory } from '@lukso/lsp-factory.js';
 
-const provider = 'https://rpc.l16.lukso.network'; // RPC url used to connect to the network
+const provider = 'https://rpc.testnet.lukso.network'; // RPC url used to connect to the network
 
 const lspFactory = new LSPFactory(provider, {
   deployKey: '0x...'; // Private key of the account which will deploy UPs

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ npm install @lukso/lsp-factory.js
 ```javascript
 import { LSPFactory } from '@lukso/lsp-factory.js';
 
-const provider = 'https://rpc.l16.lukso.network';
+const provider = 'https://rpc.testnet.lukso.network';
 
 const lspFactory = new LSPFactory(provider, {
   deployKey: '0x...', // Private key of the account which will deploy smart contracts
@@ -116,7 +116,7 @@ const myUPAddress = myContracts.LSP0ERC725Account.address;
 When instantiating LSPFactory options can be passed to specify parameters such as `chainId` and `ipfsGateway`.
 
 ```javascript title="Instantiating LSPFactory with custom options set"
-const lspFactory = new LSPFactory('https://rpc.l16.lukso.network', {
+const lspFactory = new LSPFactory('https://rpc.testnet.lukso.network', {
   deployKey: '0x...',
   chainId: 2828,
   ipfsGateway: 'https://ipfs.infura.io:5001',
@@ -138,7 +138,7 @@ If no value is set here, LSPFactory will attempt to sign transactions via a brow
 `ipfsGateway` is used to specify the IPFS node which should be interacted with for uploading and retrieving metadata. `ipfsGateway` can be either a URL string or an object as defined by the [IPFS-HTTP Client](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#createoptions) library which is used internally to interact with the IPFS node.
 
 ```javascript title="Instantiating LSPFactory with custom ipfsGateway options set"
-const lspFactory = new LSPFactory('https://rpc.l16.lukso.network', {
+const lspFactory = new LSPFactory('https://rpc.testnet.lukso.network', {
   deployKey: '0x...',
   chainId: 2828,
   ipfsGateway: {

--- a/src/lib/helpers/config.helper.ts
+++ b/src/lib/helpers/config.helper.ts
@@ -1,6 +1,7 @@
 import { Permissions } from '@erc725/erc725.js/build/main/src/types/Method';
 import { keccak256 } from '@ethersproject/keccak256';
 import { toUtf8Bytes } from '@ethersproject/strings';
+import { version as lspSmartContractsVersion } from '@lukso/lsp-smart-contracts/package.json';
 import { Options } from 'ipfs-http-client';
 
 import { UploadOptions } from '../interfaces/profile-upload-options';
@@ -59,7 +60,7 @@ export const DEFAULT_PERMISSIONS: Permissions = {
   REENTRANCY: true,
 };
 
-export const DEFAULT_CONTRACT_VERSION = '0.10.3';
+export const DEFAULT_CONTRACT_VERSION = lspSmartContractsVersion;
 
 export const GAS_PRICE = 10_000_000_000;
 export const GAS_BUFFER = 100_000;


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

**docs update**

The `main` branch still shows the docs with `l16` instead of `testnet`. This is incorrectly fetched in by the auto bot in the docs.lukso.tech PR
